### PR TITLE
feat: UI overhaul — Default Dark/Light schemes, settings panel, collapsible sidebar

### DIFF
--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+if [ "$LEFTHOOK_VERBOSE" = "1" -o "$LEFTHOOK_VERBOSE" = "true" ]; then
+  set -x
+fi
+
+if [ "$LEFTHOOK" = "0" ]; then
+  exit 0
+fi
+
+call_lefthook()
+{
+  if test -n "$LEFTHOOK_BIN"
+  then
+    "$LEFTHOOK_BIN" "$@"
+  elif lefthook -h >/dev/null 2>&1
+  then
+    lefthook "$@"
+  else
+    dir="$(git rev-parse --show-toplevel)"
+    osArch=$(uname | tr '[:upper:]' '[:lower:]')
+    cpuArch=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/x64/')
+    if test -f "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook"
+    then
+      "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/lefthook/bin/index.js"
+    then
+      "$dir/node_modules/lefthook/bin/index.js" "$@"
+    
+    elif go tool lefthook -h >/dev/null 2>&1
+    then
+      go tool lefthook "$@"
+    elif bundle exec lefthook -h >/dev/null 2>&1
+    then
+      bundle exec lefthook "$@"
+    elif yarn lefthook -h >/dev/null 2>&1
+    then
+      yarn lefthook "$@"
+    elif pnpm lefthook -h >/dev/null 2>&1
+    then
+      pnpm lefthook "$@"
+    elif swift package lefthook >/dev/null 2>&1
+    then
+      swift package --build-path .build/lefthook --disable-sandbox lefthook "$@"
+    elif command -v mint >/dev/null 2>&1
+    then
+      mint run csjones/lefthook-plugin "$@"
+    elif uv run lefthook -h >/dev/null 2>&1
+    then
+      uv run lefthook "$@"
+    elif mise exec -- lefthook -h >/dev/null 2>&1
+    then
+      mise exec -- lefthook "$@"
+    elif devbox run lefthook -h >/dev/null 2>&1
+    then
+      devbox run lefthook "$@"
+    else
+      echo "Can't find lefthook in PATH"
+    fi
+  fi
+}
+
+call_lefthook run "pre-commit" "$@"

--- a/.husky/_/prepare-commit-msg
+++ b/.husky/_/prepare-commit-msg
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+if [ "$LEFTHOOK_VERBOSE" = "1" -o "$LEFTHOOK_VERBOSE" = "true" ]; then
+  set -x
+fi
+
+if [ "$LEFTHOOK" = "0" ]; then
+  exit 0
+fi
+
+call_lefthook()
+{
+  if test -n "$LEFTHOOK_BIN"
+  then
+    "$LEFTHOOK_BIN" "$@"
+  elif lefthook -h >/dev/null 2>&1
+  then
+    lefthook "$@"
+  else
+    dir="$(git rev-parse --show-toplevel)"
+    osArch=$(uname | tr '[:upper:]' '[:lower:]')
+    cpuArch=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/x64/')
+    if test -f "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook"
+    then
+      "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/lefthook/bin/index.js"
+    then
+      "$dir/node_modules/lefthook/bin/index.js" "$@"
+    
+    elif go tool lefthook -h >/dev/null 2>&1
+    then
+      go tool lefthook "$@"
+    elif bundle exec lefthook -h >/dev/null 2>&1
+    then
+      bundle exec lefthook "$@"
+    elif yarn lefthook -h >/dev/null 2>&1
+    then
+      yarn lefthook "$@"
+    elif pnpm lefthook -h >/dev/null 2>&1
+    then
+      pnpm lefthook "$@"
+    elif swift package lefthook >/dev/null 2>&1
+    then
+      swift package --build-path .build/lefthook --disable-sandbox lefthook "$@"
+    elif command -v mint >/dev/null 2>&1
+    then
+      mint run csjones/lefthook-plugin "$@"
+    elif uv run lefthook -h >/dev/null 2>&1
+    then
+      uv run lefthook "$@"
+    elif mise exec -- lefthook -h >/dev/null 2>&1
+    then
+      mise exec -- lefthook "$@"
+    elif devbox run lefthook -h >/dev/null 2>&1
+    then
+      devbox run lefthook "$@"
+    else
+      echo "Can't find lefthook in PATH"
+    fi
+  fi
+}
+
+call_lefthook run "prepare-commit-msg" "$@"

--- a/package.json
+++ b/package.json
@@ -32,16 +32,17 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "rehype-slug": "^6.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "shiki": "^4.0.2"
   },
   "devDependencies": {
+    "@evilmartians/lefthook": "^1.11.13",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/vite": "^4.1.3",
+    "@takazudo/mdx-formatter": "^1.0.3",
     "@types/node": "^22.15.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
-    "@evilmartians/lefthook": "^1.11.13",
-    "@takazudo/mdx-formatter": "^1.0.3",
     "jsdom": "^29.0.1",
     "prettier": "^3.5.3",
     "tailwindcss": "^4.1.3",

--- a/packages/design-system/token-data.ts
+++ b/packages/design-system/token-data.ts
@@ -12,6 +12,7 @@ export interface DemoTokenConfig {
     status: DemoToken[];
   };
   typography: DemoToken[];
+  etc: DemoToken[];
   decoration: DemoToken[];
 }
 
@@ -306,6 +307,14 @@ export const demoTokenConfig: DemoTokenConfig = {
       type: "length",
     },
   ],
+  etc: [
+    {
+      variable: "--demo-padding",
+      defaultValue: "16px",
+      label: "Demo Padding",
+      type: "length",
+    },
+  ],
   decoration: [
     {
       variable: "--radius",
@@ -340,6 +349,7 @@ export function getAllTokens(config: DemoTokenConfig): DemoToken[] {
     ...config.colors.palette,
     ...config.colors.status,
     ...config.typography,
+    ...config.etc,
     ...config.decoration,
   ];
 }

--- a/packages/design-system/tokens.css
+++ b/packages/design-system/tokens.css
@@ -83,32 +83,32 @@
   --breakpoint-xl: 1280px;
 }
 
-/* Default palette (dark theme — Catppuccin Mocha-inspired, oklch) */
+/* Default palette (Default Dark — matches color-tweak-panel default preset) */
 :root {
-  --cssp-bg: oklch(0.21 0.02 281);
-  --cssp-fg: oklch(0.87 0.03 265);
-  --cssp-surface: oklch(0.28 0.02 275);
-  --cssp-muted: oklch(0.52 0.02 265);
-  --cssp-accent: oklch(0.75 0.12 253);
-  --cssp-accent-hover: oklch(0.84 0.07 253);
-  --cssp-success: oklch(0.84 0.14 145);
-  --cssp-danger: oklch(0.73 0.14 11);
-  --cssp-warning: oklch(0.91 0.09 88);
-  --cssp-info: oklch(0.84 0.08 210);
-  --cssp-0: oklch(0.14 0.01 281);
-  --cssp-1: oklch(0.73 0.14 11);
-  --cssp-2: oklch(0.84 0.14 145);
-  --cssp-3: oklch(0.91 0.09 88);
-  --cssp-4: oklch(0.75 0.12 253);
-  --cssp-5: oklch(0.83 0.1 338);
-  --cssp-6: oklch(0.85 0.09 180);
-  --cssp-7: oklch(0.87 0.03 265);
-  --cssp-8: oklch(0.44 0.02 268);
-  --cssp-9: oklch(0.73 0.14 11);
-  --cssp-10: oklch(0.84 0.14 145);
-  --cssp-11: oklch(0.91 0.09 88);
-  --cssp-12: oklch(0.75 0.12 253);
-  --cssp-13: oklch(0.83 0.1 338);
-  --cssp-14: oklch(0.85 0.09 180);
-  --cssp-15: oklch(0.8 0.03 265);
+  --cssp-bg: #181818;
+  --cssp-fg: #b8b8b8;
+  --cssp-surface: #1c1c1c;
+  --cssp-muted: #888888;
+  --cssp-accent: #d69a66;
+  --cssp-accent-hover: #a7c0e3;
+  --cssp-success: #93bb77;
+  --cssp-danger: #da6871;
+  --cssp-warning: #dfbb77;
+  --cssp-info: #5caae9;
+  --cssp-0: #1c1c1c;
+  --cssp-1: #da6871;
+  --cssp-2: #93bb77;
+  --cssp-3: #dfbb77;
+  --cssp-4: #5caae9;
+  --cssp-5: #c074d6;
+  --cssp-6: #90a1b9;
+  --cssp-7: #a0a0a0;
+  --cssp-8: #888888;
+  --cssp-9: #181818;
+  --cssp-10: #383838;
+  --cssp-11: #e0e0e0;
+  --cssp-12: #d69a66;
+  --cssp-13: #c074d6;
+  --cssp-14: #a7c0e3;
+  --cssp-15: #b8b8b8;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      shiki:
+        specifier: ^4.0.2
+        version: 4.0.2
     devDependencies:
       '@evilmartians/lefthook':
         specifier: ^1.11.13

--- a/src/components/ai-chat-modal.tsx
+++ b/src/components/ai-chat-modal.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { renderMarkdown } from "../utils/render-markdown";
+import { getCssStyle } from "../lib/settings-store";
 
 interface ChatMessage {
   role: "user" | "assistant";
@@ -125,14 +126,13 @@ export default function AiChatModal() {
             role: m.role,
             content: m.content,
           })),
+          cssStyle: getCssStyle(),
         }),
         signal: abort.signal,
       });
 
       if (!res.ok) {
-        setError(
-          await extractErrorMessage(res, `Server error ${res.status}`),
-        );
+        setError(await extractErrorMessage(res, `Server error ${res.status}`));
       } else {
         const data = await res.json();
         if (data.error) {

--- a/src/components/color-tweak-panel.tsx
+++ b/src/components/color-tweak-panel.tsx
@@ -8,17 +8,11 @@ interface TweakState {
   semanticMappings: Record<string, number>;
 }
 
+const DEFAULT_PRESET = "Default Dark";
+// Derived from the default preset to avoid duplication
 const DEFAULT_SEMANTIC_MAPPINGS: Record<string, number> = {
-  bg: 9,
-  fg: 15,
-  surface: 0,
-  muted: 8,
-  accent: 12,
-  accentHover: 14,
-  success: 2,
-  danger: 1,
-  warning: 3,
-  info: 4,
+  bg: 9, fg: 15, surface: 0, muted: 8, accent: 12,
+  accentHover: 14, success: 2, danger: 1, warning: 3, info: 4,
 };
 
 interface PresetDef {
@@ -125,8 +119,8 @@ const PANEL_WIDTH = 420;
 function loadState(): { state: TweakState; preset: string } {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
-    const rawPreset = localStorage.getItem(PRESET_KEY) || "Default Dark";
-    const preset = rawPreset in PRESETS ? rawPreset : "Default Dark";
+    const rawPreset = localStorage.getItem(PRESET_KEY) || DEFAULT_PRESET;
+    const preset = rawPreset in PRESETS ? rawPreset : DEFAULT_PRESET;
     if (saved) {
       const parsed = JSON.parse(saved);
       // Migration: convert old format (individual semantic keys) to new format
@@ -144,10 +138,10 @@ function loadState(): { state: TweakState; preset: string } {
   }
   return {
     state: {
-      palette: [...PRESETS["Default Dark"].palette],
-      semanticMappings: { ...PRESETS["Default Dark"].semanticMappings },
+      palette: [...PRESETS[DEFAULT_PRESET].palette],
+      semanticMappings: { ...PRESETS[DEFAULT_PRESET].semanticMappings },
     },
-    preset: "Default Dark",
+    preset: DEFAULT_PRESET,
   };
 }
 

--- a/src/components/color-tweak-panel.tsx
+++ b/src/components/color-tweak-panel.tsx
@@ -125,7 +125,8 @@ const PANEL_WIDTH = 420;
 function loadState(): { state: TweakState; preset: string } {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
-    const preset = localStorage.getItem(PRESET_KEY) || "Default Dark";
+    const rawPreset = localStorage.getItem(PRESET_KEY) || "Default Dark";
+    const preset = rawPreset in PRESETS ? rawPreset : "Default Dark";
     if (saved) {
       const parsed = JSON.parse(saved);
       // Migration: convert old format (individual semantic keys) to new format
@@ -284,12 +285,12 @@ export default function ColorTweakPanel() {
   };
 
   // Derive colors for panel styling from current state
-  const bgColor = state.palette[state.semanticMappings.bg ?? 0] ?? "#1e1e2e";
-  const fgColor = state.palette[state.semanticMappings.fg ?? 7] ?? "#cdd6f4";
+  const bgColor = state.palette[state.semanticMappings.bg ?? 9] ?? "#181818";
+  const fgColor = state.palette[state.semanticMappings.fg ?? 15] ?? "#b8b8b8";
   const surfaceColor =
-    state.palette[state.semanticMappings.surface ?? 0] ?? "#313244";
+    state.palette[state.semanticMappings.surface ?? 0] ?? "#1c1c1c";
   const mutedColor =
-    state.palette[state.semanticMappings.muted ?? 8] ?? "#6c7086";
+    state.palette[state.semanticMappings.muted ?? 8] ?? "#888888";
 
   // Toggle button (always visible)
   const toggleButton = (

--- a/src/components/color-tweak-panel.tsx
+++ b/src/components/color-tweak-panel.tsx
@@ -10,15 +10,15 @@ interface TweakState {
 
 const DEFAULT_SEMANTIC_MAPPINGS: Record<string, number> = {
   bg: 9,
-  fg: 7,
-  surface: 10,
-  muted: 13,
-  accent: 4,
-  accentHover: 11,
+  fg: 15,
+  surface: 0,
+  muted: 8,
+  accent: 12,
+  accentHover: 14,
   success: 2,
   danger: 1,
   warning: 3,
-  info: 12,
+  info: 4,
 };
 
 interface PresetDef {
@@ -27,96 +27,64 @@ interface PresetDef {
 }
 
 const PRESETS: Record<string, PresetDef> = {
-  "Catppuccin Mocha": {
+  "Default Dark": {
     palette: [
-      "#11111b",
-      "#f38ba8",
-      "#a6e3a1",
-      "#f9e2af",
-      "#89b4fa",
-      "#f5c2e7",
-      "#94e2d5",
-      "#cdd6f4",
-      "#585b70",
-      "#1e1e2e",
-      "#313244",
-      "#b4d0fb",
-      "#89dceb",
-      "#6c7086",
-      "#94e2d5",
-      "#bac2de",
+      "#1c1c1c",
+      "#da6871",
+      "#93bb77",
+      "#dfbb77",
+      "#5caae9",
+      "#c074d6",
+      "#90a1b9",
+      "#a0a0a0",
+      "#888888",
+      "#181818",
+      "#383838",
+      "#e0e0e0",
+      "#d69a66",
+      "#c074d6",
+      "#a7c0e3",
+      "#b8b8b8",
     ],
     semanticMappings: {
       bg: 9,
-      fg: 7,
-      surface: 10,
-      muted: 13,
-      accent: 4,
-      accentHover: 11,
-      success: 2,
-      danger: 1,
-      warning: 3,
-      info: 12,
-    },
-  },
-  Dracula: {
-    palette: [
-      "#21222c",
-      "#ff5555",
-      "#50fa7b",
-      "#f1fa8c",
-      "#bd93f9",
-      "#ff79c6",
-      "#8be9fd",
-      "#f8f8f2",
-      "#6272a4",
-      "#282a36",
-      "#86878b",
-      "#a4ffff",
-      "#d6acff",
-      "#ff92df",
-      "#69ff94",
-      "#ffffff",
-    ],
-    semanticMappings: {
-      bg: 9,
-      fg: 7,
+      fg: 15,
       surface: 0,
-      muted: 10,
-      accent: 6,
-      accentHover: 11,
+      muted: 8,
+      accent: 12,
+      accentHover: 14,
       success: 2,
       danger: 1,
       warning: 3,
       info: 4,
     },
   },
-  Nord: {
+  "Default Light": {
     palette: [
-      "#2e3440",
-      "#bf616a",
-      "#a3be8c",
-      "#ebcb8b",
-      "#81a1c1",
-      "#b48ead",
-      "#88c0d0",
-      "#e5e9f0",
-      "#4c566a",
-      "#3b4252",
-      "#616e88",
-      "#8fbcbb",
-      "#d8dee9",
-      "#b48ead",
-      "#88c0d0",
-      "#eceff4",
+      "#303030",
+      "#dd3131",
+      "#266538",
+      "#a83838",
+      "#3277c8",
+      "#a35e0f",
+      "#90a1b9",
+      "#7a5218",
+      "#6b6b6b",
+      "#e2ddda",
+      "#ece9e9",
+      "#303030",
+      "#5b99dc",
+      "#b89ee7",
+      "#8590a0",
+      "#654516",
     ],
     semanticMappings: {
-      bg: 0,
-      fg: 12,
-      surface: 9,
-      muted: 10,
-      accent: 6,
-      accentHover: 11,
+      bg: 9,
+      fg: 11,
+      surface: 10,
+      muted: 8,
+      accent: 5,
+      accentHover: 14,
       success: 2,
       danger: 1,
       warning: 3,
@@ -157,7 +125,7 @@ const PANEL_WIDTH = 420;
 function loadState(): { state: TweakState; preset: string } {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
-    const preset = localStorage.getItem(PRESET_KEY) || "Catppuccin Mocha";
+    const preset = localStorage.getItem(PRESET_KEY) || "Default Dark";
     if (saved) {
       const parsed = JSON.parse(saved);
       // Migration: convert old format (individual semantic keys) to new format
@@ -175,10 +143,10 @@ function loadState(): { state: TweakState; preset: string } {
   }
   return {
     state: {
-      palette: [...PRESETS["Catppuccin Mocha"].palette],
-      semanticMappings: { ...PRESETS["Catppuccin Mocha"].semanticMappings },
+      palette: [...PRESETS["Default Dark"].palette],
+      semanticMappings: { ...PRESETS["Default Dark"].semanticMappings },
     },
-    preset: "Catppuccin Mocha",
+    preset: "Default Dark",
   };
 }
 
@@ -337,7 +305,7 @@ export default function ColorTweakPanel() {
         borderRadius: "50%",
         border: "2px solid rgba(255,255,255,0.15)",
         background:
-          "linear-gradient(135deg, #89b4fa 0%, #f5c2e7 50%, #a6e3a1 100%)",
+          "linear-gradient(135deg, #5caae9 0%, #c074d6 50%, #93bb77 100%)",
         cursor: "pointer",
         display: "flex",
         alignItems: "center",
@@ -353,15 +321,15 @@ export default function ColorTweakPanel() {
         height="18"
         viewBox="0 0 24 24"
         fill="none"
-        stroke="#1e1e2e"
+        stroke="#181818"
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
       >
         <circle cx="12" cy="12" r="10" />
-        <circle cx="12" cy="8" r="2" fill="#1e1e2e" />
-        <circle cx="8" cy="14" r="2" fill="#1e1e2e" />
-        <circle cx="16" cy="14" r="2" fill="#1e1e2e" />
+        <circle cx="12" cy="8" r="2" fill="#181818" />
+        <circle cx="8" cy="14" r="2" fill="#181818" />
+        <circle cx="16" cy="14" r="2" fill="#181818" />
       </svg>
     </button>
   );

--- a/src/components/demo-tweak-panel.tsx
+++ b/src/components/demo-tweak-panel.tsx
@@ -159,7 +159,7 @@ export default function DemoTweakPanel() {
     fontSize: 10,
     textTransform: "uppercase",
     letterSpacing: "0.05em",
-    color: "#6c7086",
+    color: "#888888",
     marginBottom: 6,
     marginTop: 8,
     fontWeight: 600,
@@ -206,7 +206,7 @@ export default function DemoTweakPanel() {
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 11, color: "#a6adc8" }}>
+            <span style={{ fontSize: 11, color: "#b8b8b8" }}>
               {token.label}
             </span>
           </div>
@@ -249,7 +249,7 @@ export default function DemoTweakPanel() {
                 marginBottom: 4,
               }}
             >
-              <span style={{ fontSize: 11, color: "#a6adc8" }}>
+              <span style={{ fontSize: 11, color: "#b8b8b8" }}>
                 {token.label}
               </span>
               <input
@@ -263,8 +263,8 @@ export default function DemoTweakPanel() {
                 }}
                 style={{
                   width: 60,
-                  background: "#313244",
-                  color: "#cdd6f4",
+                  background: "#383838",
+                  color: "#e0e0e0",
                   border: "1px solid rgba(255,255,255,0.1)",
                   borderRadius: 3,
                   padding: "1px 4px",
@@ -290,7 +290,7 @@ export default function DemoTweakPanel() {
                 width: "100%",
                 height: 6,
                 cursor: "pointer",
-                accentColor: "#89b4fa",
+                accentColor: "#d69a66",
               }}
             />
           </div>
@@ -313,7 +313,7 @@ export default function DemoTweakPanel() {
         borderRadius: "50%",
         border: "2px solid rgba(255,255,255,0.15)",
         background:
-          "linear-gradient(135deg, #f9e2af 0%, #94e2d5 50%, #89b4fa 100%)",
+          "linear-gradient(135deg, #dfbb77 0%, #93bb77 50%, #d69a66 100%)",
         cursor: "pointer",
         display: "flex",
         alignItems: "center",
@@ -329,7 +329,7 @@ export default function DemoTweakPanel() {
         height="18"
         viewBox="0 0 24 24"
         fill="none"
-        stroke="#1e1e2e"
+        stroke="#1c1c1c"
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -337,9 +337,9 @@ export default function DemoTweakPanel() {
         <line x1="3" y1="6" x2="21" y2="6" />
         <line x1="3" y1="12" x2="21" y2="12" />
         <line x1="3" y1="18" x2="21" y2="18" />
-        <circle cx="8" cy="6" r="2" fill="#1e1e2e" />
-        <circle cx="16" cy="12" r="2" fill="#1e1e2e" />
-        <circle cx="10" cy="18" r="2" fill="#1e1e2e" />
+        <circle cx="8" cy="6" r="2" fill="#1c1c1c" />
+        <circle cx="16" cy="12" r="2" fill="#1c1c1c" />
+        <circle cx="10" cy="18" r="2" fill="#1c1c1c" />
       </svg>
     </button>
   );
@@ -358,13 +358,13 @@ export default function DemoTweakPanel() {
           width: DEMO_PANEL_WIDTH,
           maxHeight: "calc(100vh - 32px)",
           overflowY: "auto",
-          background: "#313244",
+          background: "#383838",
           border: "1px solid rgba(255,255,255,0.1)",
           borderRadius: 8,
           boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
           fontFamily: "system-ui, sans-serif",
           fontSize: 12,
-          color: "#cdd6f4",
+          color: "#e0e0e0",
         }}
       >
         {/* Title bar (draggable) */}
@@ -388,7 +388,7 @@ export default function DemoTweakPanel() {
             style={{
               background: "none",
               border: "none",
-              color: "#6c7086",
+              color: "#888888",
               cursor: "pointer",
               fontSize: 16,
               lineHeight: 1,
@@ -415,11 +415,11 @@ export default function DemoTweakPanel() {
                 padding: "6px 0",
                 fontSize: 11,
                 fontWeight: tab === t.key ? 600 : 400,
-                color: tab === t.key ? "#89b4fa" : "#6c7086",
+                color: tab === t.key ? "#d69a66" : "#888888",
                 background: "none",
                 border: "none",
                 borderBottom:
-                  tab === t.key ? "2px solid #89b4fa" : "2px solid transparent",
+                  tab === t.key ? "2px solid #d69a66" : "2px solid transparent",
                 cursor: "pointer",
               }}
             >
@@ -457,8 +457,8 @@ export default function DemoTweakPanel() {
               onClick={handleReset}
               style={{
                 width: "100%",
-                background: "#1e1e2e",
-                color: "#6c7086",
+                background: "#1c1c1c",
+                color: "#888888",
                 border: "1px solid rgba(255,255,255,0.1)",
                 borderRadius: 4,
                 padding: "5px 8px",

--- a/src/components/demo-tweak-panel.tsx
+++ b/src/components/demo-tweak-panel.tsx
@@ -12,7 +12,7 @@ import { hexToHsl, hslToHex, hslToCssString } from "../lib/color-convert";
 import HslPicker from "./hsl-picker";
 import { useDraggable } from "../hooks/use-draggable";
 
-type Tab = "color" | "typography" | "spacing";
+type Tab = "color" | "typography" | "spacing" | "etc";
 
 interface DemoTweakState {
   colors: Record<string, string>;
@@ -153,6 +153,7 @@ export default function DemoTweakPanel() {
     { key: "color", label: "Color" },
     { key: "typography", label: "Typography" },
     { key: "spacing", label: "Spacing" },
+    { key: "etc", label: "Etc" },
   ];
 
   const sectionHeaderStyle: React.CSSProperties = {
@@ -449,6 +450,11 @@ export default function DemoTweakPanel() {
           {tab === "spacing" &&
             getSliderGroups()
               .filter((g) => g.id === "spacing" || g.id === "decoration")
+              .map(renderSliderGroup)}
+
+          {tab === "etc" &&
+            getSliderGroups()
+              .filter((g) => g.id === "etc")
               .map(renderSliderGroup)}
 
           {/* Reset button */}

--- a/src/components/highlighted-code.tsx
+++ b/src/components/highlighted-code.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import type { HighlighterCore } from "shiki";
+import { getShikiTheme, type ShikiTheme } from "../lib/settings-store";
+
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+let loadedTheme: string | null = null;
+
+function getHighlighter(theme: ShikiTheme): Promise<HighlighterCore> {
+  if (!highlighterPromise || loadedTheme !== theme) {
+    loadedTheme = theme;
+    highlighterPromise = import("shiki")
+      .then(({ createHighlighter }) =>
+        createHighlighter({
+          themes: [theme],
+          langs: ["html", "css"],
+        }),
+      )
+      .catch((err) => {
+        highlighterPromise = null;
+        loadedTheme = null;
+        throw err;
+      });
+  }
+  return highlighterPromise;
+}
+
+interface HighlightedCodeProps {
+  code: string;
+  language: "html" | "css";
+}
+
+export default function HighlightedCode({
+  code,
+  language,
+}: HighlightedCodeProps) {
+  const [highlighted, setHighlighted] = useState<string | null>(null);
+  const [theme, setTheme] = useState<ShikiTheme>(() => getShikiTheme());
+
+  // Listen for theme changes from settings panel
+  useEffect(() => {
+    const handler = () => setTheme(getShikiTheme());
+    window.addEventListener("cssp-shiki-theme-change", handler);
+    return () => window.removeEventListener("cssp-shiki-theme-change", handler);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setHighlighted(null); // Show fallback while loading new theme
+    getHighlighter(theme)
+      .then((highlighter) => {
+        if (cancelled) return;
+        const result = highlighter.codeToHtml(code, {
+          lang: language,
+          theme,
+        });
+        setHighlighted(result);
+      })
+      .catch(() => {
+        // Shiki failed — keep plain-text fallback
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [code, language, theme]);
+
+  if (!highlighted) {
+    return (
+      <pre className="text-caption text-fg/80 whitespace-pre-wrap break-words m-0">
+        <code>{code}</code>
+      </pre>
+    );
+  }
+
+  return (
+    <div
+      className="cssp-highlighted-code"
+      dangerouslySetInnerHTML={{ __html: highlighted }}
+    />
+  );
+}

--- a/src/components/html-preview.tsx
+++ b/src/components/html-preview.tsx
@@ -43,12 +43,13 @@ export default function HtmlPreview({
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-body { font-family: system-ui, sans-serif; }
+body { font-family: system-ui, sans-serif; background-color: var(--bg, #fff); color: var(--fg, #222); }
 input, button, textarea, select { font-family: inherit; }
 :focus-visible { outline: 2px solid var(--accent, hsl(220 70% 50%)); outline-offset: 2px; }
 ${baseTokensCss}
 ${css}
 </style>
+<script src="https://unpkg.com/@tailwindcss/browser@4"></script>
 </head>
 <body>${html}</body>
 <script>

--- a/src/components/html-preview.tsx
+++ b/src/components/html-preview.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { generateBaseTokensCss } from "../lib/demo-tokens";
 import { registerIframe, unregisterIframe } from "../lib/iframe-registry";
+import HighlightedCode from "./highlighted-code";
 
 type Viewport = "mobile" | "tablet" | "full";
 
@@ -36,7 +37,8 @@ export default function HtmlPreview({
 
   const baseTokensCss = useMemo(() => generateBaseTokensCss(), []);
 
-  const srcdoc = useMemo(() => `<!doctype html>
+  const srcdoc = useMemo(
+    () => `<!doctype html>
 <html>
 <head>
 <meta charset="UTF-8">
@@ -74,7 +76,9 @@ window.addEventListener("message", function(e) {
   }
 });
 </script>
-</html>`, [html, css, baseTokensCss]);
+</html>`,
+    [html, css, baseTokensCss],
+  );
 
   const measureHeight = useCallback(() => {
     const iframe = iframeRef.current;
@@ -216,9 +220,7 @@ window.addEventListener("message", function(e) {
             <div className="mb-vsp-xs">
               <span className="text-caption text-muted font-medium">HTML</span>
             </div>
-            <pre className="text-caption text-fg/80 whitespace-pre-wrap break-words m-0">
-              <code>{html}</code>
-            </pre>
+            <HighlightedCode code={html} language="html" />
             {css && (
               <>
                 <div className="mt-vsp-sm mb-vsp-xs">
@@ -226,9 +228,7 @@ window.addEventListener("message", function(e) {
                     CSS
                   </span>
                 </div>
-                <pre className="text-caption text-fg/80 whitespace-pre-wrap break-words m-0">
-                  <code>{css}</code>
-                </pre>
+                <HighlightedCode code={css} language="css" />
               </>
             )}
           </div>

--- a/src/components/html-preview.tsx
+++ b/src/components/html-preview.tsx
@@ -43,7 +43,7 @@ export default function HtmlPreview({
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-body { font-family: system-ui, sans-serif; background-color: var(--bg, #fff); color: var(--fg, #222); }
+body { font-family: system-ui, sans-serif; background-color: var(--bg, #fff); color: var(--fg, #222); padding: var(--demo-padding, 16px); }
 input, button, textarea, select { font-family: inherit; }
 :focus-visible { outline: 2px solid var(--accent, hsl(220 70% 50%)); outline-offset: 2px; }
 ${baseTokensCss}

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -1,12 +1,23 @@
 import { useState, useEffect } from "react";
 import { useDraggable } from "../hooks/use-draggable";
-import { getCssStyle, setCssStyle, type CssStyle } from "../lib/settings-store";
+import {
+  getCssStyle,
+  setCssStyle,
+  getShikiTheme,
+  setShikiTheme,
+  SHIKI_THEMES,
+  type CssStyle,
+  type ShikiTheme,
+} from "../lib/settings-store";
 
 const PANEL_WIDTH = 280;
 
 export default function SettingsPanel() {
   const [open, setOpen] = useState(false);
   const [cssStyle, setCssStyleState] = useState<CssStyle>(() => getCssStyle());
+  const [shikiTheme, setShikiThemeState] = useState<ShikiTheme>(() =>
+    getShikiTheme(),
+  );
   const { position, onMouseDown, recenter } = useDraggable(PANEL_WIDTH);
 
   useEffect(() => {
@@ -18,6 +29,11 @@ export default function SettingsPanel() {
   const handleCssStyleChange = (value: CssStyle) => {
     setCssStyleState(value);
     setCssStyle(value);
+  };
+
+  const handleShikiThemeChange = (value: ShikiTheme) => {
+    setShikiThemeState(value);
+    setShikiTheme(value);
   };
 
   const toggleButton = (
@@ -153,6 +169,52 @@ export default function SettingsPanel() {
               >
                 <option value="tailwind">Tailwind CSS</option>
                 <option value="general">General CSS</option>
+              </select>
+            </div>
+
+            {/* Shiki Theme */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+                marginTop: 10,
+              }}
+            >
+              <label
+                htmlFor="cssp-shiki-theme-select"
+                style={{
+                  fontSize: 12,
+                  color: "#b8b8b8",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                Code Theme
+              </label>
+              <select
+                id="cssp-shiki-theme-select"
+                value={shikiTheme}
+                onChange={(e) =>
+                  handleShikiThemeChange(e.target.value as ShikiTheme)
+                }
+                style={{
+                  flex: 1,
+                  maxWidth: 160,
+                  background: "#383838",
+                  color: "#e0e0e0",
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  borderRadius: 4,
+                  padding: "4px 8px",
+                  fontSize: 11,
+                  cursor: "pointer",
+                }}
+              >
+                {SHIKI_THEMES.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
               </select>
             </div>
           </div>

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -27,7 +27,7 @@ export default function SettingsPanel() {
         position: "fixed",
         top: 12,
         right: 100,
-        zIndex: 10000,
+        zIndex: 10001,
         width: 36,
         height: 36,
         borderRadius: "50%",
@@ -43,6 +43,7 @@ export default function SettingsPanel() {
         padding: 0,
       }}
       title="Toggle Settings Panel"
+      aria-label="Toggle Settings Panel"
     >
       <svg
         width="18"
@@ -69,7 +70,7 @@ export default function SettingsPanel() {
             position: "fixed",
             left: position.x,
             top: position.y,
-            zIndex: 9999,
+            zIndex: 10000,
             width: PANEL_WIDTH,
             background: "#1c1c1c",
             border: "1px solid rgba(255,255,255,0.1)",

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -6,12 +6,8 @@ const PANEL_WIDTH = 280;
 
 export default function SettingsPanel() {
   const [open, setOpen] = useState(false);
-  const [cssStyle, setCssStyleState] = useState<CssStyle>("tailwind");
+  const [cssStyle, setCssStyleState] = useState<CssStyle>(() => getCssStyle());
   const { position, onMouseDown, recenter } = useDraggable(PANEL_WIDTH);
-
-  useEffect(() => {
-    setCssStyleState(getCssStyle());
-  }, []);
 
   useEffect(() => {
     if (open) {
@@ -64,101 +60,103 @@ export default function SettingsPanel() {
     </button>
   );
 
-  if (!open) return toggleButton;
-
   return (
     <>
       {toggleButton}
-      <div
-        style={{
-          position: "fixed",
-          left: position.x,
-          top: position.y,
-          zIndex: 9999,
-          width: PANEL_WIDTH,
-          background: "#1c1c1c",
-          border: "1px solid rgba(255,255,255,0.1)",
-          borderRadius: 8,
-          boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
-          fontFamily: "system-ui, sans-serif",
-          fontSize: 12,
-          color: "#e0e0e0",
-        }}
-      >
-        {/* Title bar (draggable) */}
+      {open && (
         <div
-          onMouseDown={onMouseDown}
-          aria-label="Drag to move Settings panel"
           style={{
-            padding: "8px 12px",
-            cursor: "grab",
-            borderBottom: "1px solid rgba(255,255,255,0.08)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            userSelect: "none",
+            position: "fixed",
+            left: position.x,
+            top: position.y,
+            zIndex: 9999,
+            width: PANEL_WIDTH,
+            background: "#1c1c1c",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: 8,
+            boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
+            fontFamily: "system-ui, sans-serif",
+            fontSize: 12,
+            color: "#e0e0e0",
           }}
         >
-          <span style={{ fontWeight: 600, fontSize: 13 }}>Settings</span>
-          <button
-            onClick={() => setOpen(false)}
-            aria-label="Close"
-            style={{
-              background: "none",
-              border: "none",
-              color: "#888888",
-              cursor: "pointer",
-              fontSize: 16,
-              lineHeight: 1,
-              padding: "0 2px",
-            }}
-          >
-            ×
-          </button>
-        </div>
-
-        {/* Content */}
-        <div style={{ padding: "12px" }}>
+          {/* Title bar (draggable) */}
           <div
+            onMouseDown={onMouseDown}
+            aria-label="Drag to move Settings panel"
             style={{
+              padding: "8px 12px",
+              cursor: "grab",
+              borderBottom: "1px solid rgba(255,255,255,0.08)",
               display: "flex",
               alignItems: "center",
               justifyContent: "space-between",
-              gap: 12,
+              userSelect: "none",
             }}
           >
-            <label
-              htmlFor="cssp-css-style-select"
+            <span style={{ fontWeight: 600, fontSize: 13 }}>Settings</span>
+            <button
+              onClick={() => setOpen(false)}
+              aria-label="Close"
               style={{
-                fontSize: 12,
-                color: "#b8b8b8",
-                whiteSpace: "nowrap",
-              }}
-            >
-              CSS Style
-            </label>
-            <select
-              id="cssp-css-style-select"
-              value={cssStyle}
-              onChange={(e) => handleCssStyleChange(e.target.value as CssStyle)}
-              style={{
-                flex: 1,
-                maxWidth: 160,
-                background: "#383838",
-                color: "#e0e0e0",
-                border: "1px solid rgba(255,255,255,0.1)",
-                borderRadius: 4,
-                padding: "4px 8px",
-                fontSize: 11,
+                background: "none",
+                border: "none",
+                color: "#888888",
                 cursor: "pointer",
+                fontSize: 16,
+                lineHeight: 1,
+                padding: "0 2px",
               }}
             >
-              <option value="tailwind">Tailwind CSS</option>
-              <option value="general">General CSS</option>
-            </select>
+              ×
+            </button>
+          </div>
+
+          {/* Content */}
+          <div style={{ padding: "12px" }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+              }}
+            >
+              <label
+                htmlFor="cssp-css-style-select"
+                style={{
+                  fontSize: 12,
+                  color: "#b8b8b8",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                CSS Style
+              </label>
+              <select
+                id="cssp-css-style-select"
+                value={cssStyle}
+                onChange={(e) =>
+                  handleCssStyleChange(e.target.value as CssStyle)
+                }
+                style={{
+                  flex: 1,
+                  maxWidth: 160,
+                  background: "#383838",
+                  color: "#e0e0e0",
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  borderRadius: 4,
+                  padding: "4px 8px",
+                  fontSize: 11,
+                  cursor: "pointer",
+                }}
+              >
+                <option value="tailwind">Tailwind CSS</option>
+                <option value="general">General CSS</option>
+              </select>
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </>
   );
 }

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect } from "react";
+import { useDraggable } from "../hooks/use-draggable";
+import { getCssStyle, setCssStyle, type CssStyle } from "../lib/settings-store";
+
+const PANEL_WIDTH = 280;
+
+export default function SettingsPanel() {
+  const [open, setOpen] = useState(false);
+  const [cssStyle, setCssStyleState] = useState<CssStyle>("tailwind");
+  const { position, onMouseDown, recenter } = useDraggable(PANEL_WIDTH);
+
+  useEffect(() => {
+    setCssStyleState(getCssStyle());
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      recenter();
+    }
+  }, [open, recenter]);
+
+  const handleCssStyleChange = (value: CssStyle) => {
+    setCssStyleState(value);
+    setCssStyle(value);
+  };
+
+  const toggleButton = (
+    <button
+      onClick={() => setOpen((o) => !o)}
+      style={{
+        position: "fixed",
+        top: 12,
+        right: 100,
+        zIndex: 10000,
+        width: 36,
+        height: 36,
+        borderRadius: "50%",
+        border: "2px solid rgba(255,255,255,0.15)",
+        background:
+          "linear-gradient(135deg, #585b70 0%, #6c7086 50%, #888888 100%)",
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: 16,
+        boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
+        padding: 0,
+      }}
+      title="Toggle Settings Panel"
+    >
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="#e0e0e0"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+      </svg>
+    </button>
+  );
+
+  if (!open) return toggleButton;
+
+  return (
+    <>
+      {toggleButton}
+      <div
+        style={{
+          position: "fixed",
+          left: position.x,
+          top: position.y,
+          zIndex: 9999,
+          width: PANEL_WIDTH,
+          background: "#1c1c1c",
+          border: "1px solid rgba(255,255,255,0.1)",
+          borderRadius: 8,
+          boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
+          fontFamily: "system-ui, sans-serif",
+          fontSize: 12,
+          color: "#e0e0e0",
+        }}
+      >
+        {/* Title bar (draggable) */}
+        <div
+          onMouseDown={onMouseDown}
+          aria-label="Drag to move Settings panel"
+          style={{
+            padding: "8px 12px",
+            cursor: "grab",
+            borderBottom: "1px solid rgba(255,255,255,0.08)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            userSelect: "none",
+          }}
+        >
+          <span style={{ fontWeight: 600, fontSize: 13 }}>Settings</span>
+          <button
+            onClick={() => setOpen(false)}
+            aria-label="Close"
+            style={{
+              background: "none",
+              border: "none",
+              color: "#888888",
+              cursor: "pointer",
+              fontSize: 16,
+              lineHeight: 1,
+              padding: "0 2px",
+            }}
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Content */}
+        <div style={{ padding: "12px" }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 12,
+            }}
+          >
+            <label
+              htmlFor="cssp-css-style-select"
+              style={{
+                fontSize: 12,
+                color: "#b8b8b8",
+                whiteSpace: "nowrap",
+              }}
+            >
+              CSS Style
+            </label>
+            <select
+              id="cssp-css-style-select"
+              value={cssStyle}
+              onChange={(e) => handleCssStyleChange(e.target.value as CssStyle)}
+              style={{
+                flex: 1,
+                maxWidth: 160,
+                background: "#383838",
+                color: "#e0e0e0",
+                border: "1px solid rgba(255,255,255,0.1)",
+                borderRadius: 4,
+                padding: "4px 8px",
+                fontSize: 11,
+                cursor: "pointer",
+              }}
+            >
+              <option value="tailwind">Tailwind CSS</option>
+              <option value="general">General CSS</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/sidebar-nav.tsx
+++ b/src/components/sidebar-nav.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 
 // Static categories populated by AI chat (update-sidebar-nav.ts still works)
-const aiCategories: { slug: string; label: string; count: number }[] = [];
+const aiCategories: { slug: string; label: string; count: number }[] = [
+  { slug: "header-menus", label: "Header Menus", count: 10 },
+];
 
 interface Props {
   activeCategory?: string;

--- a/src/components/sidebar-nav.tsx
+++ b/src/components/sidebar-nav.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 // Static categories populated by AI chat (update-sidebar-nav.ts still works)
 const aiCategories: { slug: string; label: string; count: number }[] = [
   { slug: "header-menus", label: "Header Menus", count: 10 },
+  { slug: "buttons", label: "Buttons", count: 10 },
+  { slug: "tab-menus", label: "Tab Menus", count: 10 },
 ];
 
 interface Props {

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -50,51 +50,81 @@ const { title, activeCategory } = Astro.props;
         id="sidebar-toggle"
         type="button"
         title="Toggle sidebar"
-        style="position: fixed; bottom: 16px; left: 16px; z-index: 100; width: 56px; height: 56px; border-radius: 50%; border: 2px solid rgba(255,255,255,0.3); background: rgba(30,28,26,0.95); color: #ccc; cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 24px; line-height: 1; padding: 0; box-shadow: 0 4px 12px rgba(0,0,0,0.5); backdrop-filter: blur(8px); transition: background 0.2s, border-color 0.2s, transform 0.15s;"
-        onmouseenter="this.style.borderColor='rgba(255,255,255,0.5)';this.style.background='rgba(50,48,46,0.95)';this.style.transform='scale(1.05)'"
-        onmouseleave="this.style.borderColor='rgba(255,255,255,0.3)';this.style.background='rgba(30,28,26,0.95)';this.style.transform='scale(1)'"
+        aria-label="Toggle sidebar"
+        aria-expanded="true"
       >
         ◀
       </button>
+      <style>
+        #sidebar-toggle {
+          position: fixed;
+          bottom: 16px;
+          left: 16px;
+          z-index: 100;
+          width: 56px;
+          height: 56px;
+          border-radius: 50%;
+          border: 2px solid rgba(255,255,255,0.3);
+          background: rgba(30,28,26,0.95);
+          color: #ccc;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 24px;
+          line-height: 1;
+          padding: 0;
+          box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+          backdrop-filter: blur(8px);
+          transition: background 0.2s, border-color 0.2s, transform 0.15s;
+        }
+        #sidebar-toggle:hover,
+        #sidebar-toggle:focus-visible {
+          border-color: rgba(255,255,255,0.5);
+          background: rgba(50,48,46,0.95);
+          transform: scale(1.05);
+        }
+      </style>
     </div>
     <ColorTweakPanel client:idle />
     <DemoTweakPanel client:idle />
     <SettingsPanel client:idle />
     <AiChatModal client:load />
-    <script>
-      const btn = document.getElementById('sidebar-toggle')!;
-      const sidebar = document.getElementById('sidebar-container')!;
-      const STORAGE_KEY = 'cssp-sidebar-collapsed';
-      let collapsed = localStorage.getItem(STORAGE_KEY) === 'true';
+    <script is:inline>
+      var btn = document.getElementById('sidebar-toggle');
+      var sidebar = document.getElementById('sidebar-container');
+      var STORAGE_KEY = 'cssp-sidebar-collapsed';
+      var collapsed = localStorage.getItem(STORAGE_KEY) === 'true';
 
-      const SIDEBAR_WIDTH = 250;
+      var SIDEBAR_WIDTH = 250;
 
-      function apply(animate = true) {
+      function apply(animate) {
         if (!animate) {
           sidebar.style.transition = 'none';
         }
         if (collapsed) {
-          sidebar.style.marginLeft = `-${SIDEBAR_WIDTH}px`;
-          btn.textContent = '▶';
+          sidebar.style.marginLeft = '-' + SIDEBAR_WIDTH + 'px';
+          btn.textContent = '\u25B6';
           btn.style.opacity = '0.5';
+          btn.setAttribute('aria-expanded', 'false');
         } else {
           sidebar.style.marginLeft = '0';
-          btn.textContent = '◀';
+          btn.textContent = '\u25C0';
           btn.style.opacity = '1';
+          btn.setAttribute('aria-expanded', 'true');
         }
         if (!animate) {
-          sidebar.offsetHeight; // force reflow
+          sidebar.offsetHeight;
           sidebar.style.transition = '';
         }
       }
 
-      // Apply saved state without animation to avoid flash
       apply(false);
 
-      btn.addEventListener('click', () => {
+      btn.addEventListener('click', function() {
         collapsed = !collapsed;
         localStorage.setItem(STORAGE_KEY, String(collapsed));
-        apply();
+        apply(true);
       });
     </script>
   </body>

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -4,6 +4,7 @@ import SidebarNav from "../components/sidebar-nav.tsx";
 import ColorTweakPanel from "../components/color-tweak-panel.tsx";
 import DemoTweakPanel from "../components/demo-tweak-panel.tsx";
 import AiChatModal from "../components/ai-chat-modal.tsx";
+import SettingsPanel from "../components/settings-panel.tsx";
 
 interface Props {
   title: string;
@@ -44,6 +45,7 @@ const { title, activeCategory } = Astro.props;
     </div>
     <ColorTweakPanel client:idle />
     <DemoTweakPanel client:idle />
+    <SettingsPanel client:idle />
     <AiChatModal client:load />
   </body>
 </html>

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -24,7 +24,7 @@ const { title, activeCategory } = Astro.props;
     <div class="flex min-h-screen">
       <aside
         id="sidebar-container"
-        class="w-[250px] shrink-0 bg-surface border-r border-r-muted/20 p-vsp-md"
+        class="w-[250px] shrink-0 overflow-hidden bg-surface border-r border-r-muted/20 p-vsp-md"
         style="transition: margin-left 0.2s ease;"
       >
         <div class="mb-vsp-lg">
@@ -65,9 +65,14 @@ const { title, activeCategory } = Astro.props;
       const STORAGE_KEY = 'cssp-sidebar-collapsed';
       let collapsed = localStorage.getItem(STORAGE_KEY) === 'true';
 
-      function apply() {
+      const SIDEBAR_WIDTH = 250;
+
+      function apply(animate = true) {
+        if (!animate) {
+          sidebar.style.transition = 'none';
+        }
         if (collapsed) {
-          sidebar.style.marginLeft = `-${sidebar.offsetWidth}px`;
+          sidebar.style.marginLeft = `-${SIDEBAR_WIDTH}px`;
           btn.textContent = '▶';
           btn.style.opacity = '0.5';
         } else {
@@ -75,9 +80,14 @@ const { title, activeCategory } = Astro.props;
           btn.textContent = '◀';
           btn.style.opacity = '1';
         }
+        if (!animate) {
+          sidebar.offsetHeight; // force reflow
+          sidebar.style.transition = '';
+        }
       }
 
-      apply();
+      // Apply saved state without animation to avoid flash
+      apply(false);
 
       btn.addEventListener('click', () => {
         collapsed = !collapsed;

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -22,7 +22,11 @@ const { title, activeCategory } = Astro.props;
   </head>
   <body class="min-h-screen">
     <div class="flex min-h-screen">
-      <aside class="w-[250px] shrink-0 bg-surface border-r border-r-muted/20 p-vsp-md">
+      <aside
+        id="sidebar-container"
+        class="w-[250px] shrink-0 bg-surface border-r border-r-muted/20 p-vsp-md"
+        style="transition: margin-left 0.2s ease;"
+      >
         <div class="mb-vsp-lg">
           <a href="/" class="text-subheading font-bold text-accent no-underline">
             CSS Playground
@@ -41,9 +45,45 @@ const { title, activeCategory } = Astro.props;
       <main class="flex-1 p-vsp-xl overflow-auto">
         <slot />
       </main>
+      <button
+        id="sidebar-toggle"
+        type="button"
+        title="Toggle sidebar"
+        style="position: fixed; bottom: 16px; left: 16px; z-index: 100; width: 56px; height: 56px; border-radius: 50%; border: 2px solid rgba(255,255,255,0.3); background: rgba(30,28,26,0.95); color: #ccc; cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 24px; line-height: 1; padding: 0; box-shadow: 0 4px 12px rgba(0,0,0,0.5); backdrop-filter: blur(8px); transition: background 0.2s, border-color 0.2s, transform 0.15s;"
+        onmouseenter="this.style.borderColor='rgba(255,255,255,0.5)';this.style.background='rgba(50,48,46,0.95)';this.style.transform='scale(1.05)'"
+        onmouseleave="this.style.borderColor='rgba(255,255,255,0.3)';this.style.background='rgba(30,28,26,0.95)';this.style.transform='scale(1)'"
+      >
+        ◀
+      </button>
     </div>
     <ColorTweakPanel client:idle />
     <DemoTweakPanel client:idle />
     <AiChatModal client:load />
+    <script>
+      const btn = document.getElementById('sidebar-toggle')!;
+      const sidebar = document.getElementById('sidebar-container')!;
+      const STORAGE_KEY = 'cssp-sidebar-collapsed';
+      let collapsed = localStorage.getItem(STORAGE_KEY) === 'true';
+
+      function apply() {
+        if (collapsed) {
+          sidebar.style.marginLeft = `-${sidebar.offsetWidth}px`;
+          btn.textContent = '▶';
+          btn.style.opacity = '0.5';
+        } else {
+          sidebar.style.marginLeft = '0';
+          btn.textContent = '◀';
+          btn.style.opacity = '1';
+        }
+      }
+
+      apply();
+
+      btn.addEventListener('click', () => {
+        collapsed = !collapsed;
+        localStorage.setItem(STORAGE_KEY, String(collapsed));
+        apply();
+      });
+    </script>
   </body>
 </html>

--- a/src/lib/ai-system-prompt.ts
+++ b/src/lib/ai-system-prompt.ts
@@ -1,4 +1,6 @@
-export const SYSTEM_PROMPT = `You are the CSS Playground AI assistant. You CREATE UI pattern pages — you do NOT just show code.
+import type { CssStyle } from "./settings-store";
+
+const BASE_PROMPT = `You are the CSS Playground AI assistant. You CREATE UI pattern pages — you do NOT just show code.
 
 When the user asks you to create patterns (e.g., "make 10 breadcrumb patterns"), you MUST:
 1. Respond with a JSON object containing the files to write
@@ -31,8 +33,28 @@ import HtmlPreview from '../components/html-preview.tsx';
       <HtmlPreview client:visible title="Pattern Name" html={\`...\`} css={\`...\`} height={60} />
     </section>
   </div>
-</BaseLayout>
+</BaseLayout>`;
 
+const TAILWIND_CSS_RULES = `
+CRITICAL CSS RULES — generate examples using Tailwind CSS utility classes:
+- Use Tailwind utility classes directly in the HTML (e.g., class="flex items-center gap-4 p-4 rounded-lg bg-[var(--bg)] text-[var(--fg)]")
+- Color values MUST reference token variables via arbitrary value syntax: bg-[var(--accent)], text-[var(--fg)], border-[var(--border)]
+- Spacing: use Tailwind spacing (p-2, gap-4, m-4 etc.) or token variables via arbitrary values
+- Typography: use Tailwind text sizes or token variables
+- Use Tailwind classes for layout (flex, grid), borders (rounded-lg, border), shadows (shadow-md), etc.
+- Token variables for colors: var(--accent), var(--accent-hover), var(--fg), var(--fg-muted), var(--bg), var(--bg-subtle), var(--border)
+- Status colors: var(--success), var(--danger), var(--warning), var(--info)
+- Radius: var(--radius) (8px)
+- Shadows: var(--shadow), var(--shadow-strong)
+- Focus: var(--focus-ring)
+- Font: font-family: system-ui, sans-serif (already set by iframe)
+- Form controls inherit font (already set by iframe)
+- :focus-visible outline already set by iframe
+
+NEVER use arbitrary hex colors or hsl() values for colors. Color values MUST come from token variables.
+Minimal custom CSS — prefer Tailwind classes. Only use custom CSS when Tailwind cannot express the pattern.`;
+
+const GENERAL_CSS_RULES = `
 CRITICAL CSS RULES — every pattern CSS MUST use these token variables:
 - Spacing: var(--space-xs) (8px), var(--space-sm) (12px), var(--space-md) (20px), var(--space-lg) (32px)
 - Colors: var(--accent), var(--accent-hover), var(--fg), var(--fg-muted), var(--bg), var(--bg-subtle), var(--border)
@@ -46,10 +68,21 @@ CRITICAL CSS RULES — every pattern CSS MUST use these token variables:
 - :focus-visible outline already set by iframe
 
 NEVER use arbitrary hex colors, hsl() values, or pixel values for spacing. EVERY value must come from a token variable.
-Use BEM-ish class names. CSS-only interactions (no JavaScript).
+Use BEM-ish class names. CSS-only interactions (no JavaScript).`;
+
+const CHAT_FALLBACK = `
 
 If the user asks a general question (not about creating patterns), respond with:
 {
   "action": "chat",
   "message": "Your answer here"
 }`;
+
+export function getSystemPrompt(cssStyle: CssStyle = "tailwind"): string {
+  const cssRules =
+    cssStyle === "general" ? GENERAL_CSS_RULES : TAILWIND_CSS_RULES;
+  return BASE_PROMPT + cssRules + CHAT_FALLBACK;
+}
+
+/** @deprecated Use getSystemPrompt() instead for CSS-style-aware prompts */
+export const SYSTEM_PROMPT = BASE_PROMPT + GENERAL_CSS_RULES + CHAT_FALLBACK;

--- a/src/lib/ai-system-prompt.ts
+++ b/src/lib/ai-system-prompt.ts
@@ -83,6 +83,3 @@ export function getSystemPrompt(cssStyle: CssStyle = "tailwind"): string {
     cssStyle === "general" ? GENERAL_CSS_RULES : TAILWIND_CSS_RULES;
   return BASE_PROMPT + cssRules + CHAT_FALLBACK;
 }
-
-/** @deprecated Use getSystemPrompt() instead for CSS-style-aware prompts */
-export const SYSTEM_PROMPT = BASE_PROMPT + GENERAL_CSS_RULES + CHAT_FALLBACK;

--- a/src/lib/ai-system-prompt.ts
+++ b/src/lib/ai-system-prompt.ts
@@ -52,9 +52,14 @@ NEVER use arbitrary hex colors, hsl() values, or pixel values for spacing. EVERY
 CSS-only interactions (no JavaScript).`;
 
 const TAILWIND_CSS_RULES = `
-CRITICAL CSS RULES — generate compact, utility-style CSS.
-Write styles as short single-purpose CSS classes (one property per class where practical), similar to Tailwind's utility approach but as plain CSS. Prefer composing multiple small classes in the HTML rather than writing large multi-property selectors.
-Example: .flex { display: flex } .gap-md { gap: var(--space-md) } .rounded { border-radius: var(--radius) }
+CRITICAL CSS RULES — generate examples using Tailwind CSS v4 utility classes.
+The preview iframe has Tailwind CSS v4 loaded via browser CDN. Use Tailwind utility classes directly in the HTML.
+- Use Tailwind classes for layout, spacing, colors, typography, etc.
+- For custom color values, use arbitrary value syntax: bg-[var(--accent)], text-[var(--fg)], border-[var(--border)]
+- For spacing with tokens: p-[var(--space-md)], gap-[var(--space-sm)], etc.
+- Standard Tailwind spacing (p-4, gap-2, m-4) is also fine for layout
+- Use Tailwind classes: flex, grid, items-center, justify-between, rounded-lg, shadow-md, etc.
+- The css prop should be minimal or empty — put styling in Tailwind classes on the HTML elements
 ${TOKEN_RULES}`;
 
 const GENERAL_CSS_RULES = `

--- a/src/lib/ai-system-prompt.ts
+++ b/src/lib/ai-system-prompt.ts
@@ -35,27 +35,8 @@ import HtmlPreview from '../components/html-preview.tsx';
   </div>
 </BaseLayout>`;
 
-const TAILWIND_CSS_RULES = `
-CRITICAL CSS RULES — generate examples using Tailwind CSS utility classes:
-- Use Tailwind utility classes directly in the HTML (e.g., class="flex items-center gap-4 p-4 rounded-lg bg-[var(--bg)] text-[var(--fg)]")
-- Color values MUST reference token variables via arbitrary value syntax: bg-[var(--accent)], text-[var(--fg)], border-[var(--border)]
-- Spacing: use Tailwind spacing (p-2, gap-4, m-4 etc.) or token variables via arbitrary values
-- Typography: use Tailwind text sizes or token variables
-- Use Tailwind classes for layout (flex, grid), borders (rounded-lg, border), shadows (shadow-md), etc.
-- Token variables for colors: var(--accent), var(--accent-hover), var(--fg), var(--fg-muted), var(--bg), var(--bg-subtle), var(--border)
-- Status colors: var(--success), var(--danger), var(--warning), var(--info)
-- Radius: var(--radius) (8px)
-- Shadows: var(--shadow), var(--shadow-strong)
-- Focus: var(--focus-ring)
-- Font: font-family: system-ui, sans-serif (already set by iframe)
-- Form controls inherit font (already set by iframe)
-- :focus-visible outline already set by iframe
-
-NEVER use arbitrary hex colors or hsl() values for colors. Color values MUST come from token variables.
-Minimal custom CSS — prefer Tailwind classes. Only use custom CSS when Tailwind cannot express the pattern.`;
-
-const GENERAL_CSS_RULES = `
-CRITICAL CSS RULES — every pattern CSS MUST use these token variables:
+const TOKEN_RULES = `
+Available token variables:
 - Spacing: var(--space-xs) (8px), var(--space-sm) (12px), var(--space-md) (20px), var(--space-lg) (32px)
 - Colors: var(--accent), var(--accent-hover), var(--fg), var(--fg-muted), var(--bg), var(--bg-subtle), var(--border)
 - Status: var(--success), var(--danger), var(--warning), var(--info)
@@ -68,7 +49,18 @@ CRITICAL CSS RULES — every pattern CSS MUST use these token variables:
 - :focus-visible outline already set by iframe
 
 NEVER use arbitrary hex colors, hsl() values, or pixel values for spacing. EVERY value must come from a token variable.
-Use BEM-ish class names. CSS-only interactions (no JavaScript).`;
+CSS-only interactions (no JavaScript).`;
+
+const TAILWIND_CSS_RULES = `
+CRITICAL CSS RULES — generate compact, utility-style CSS.
+Write styles as short single-purpose CSS classes (one property per class where practical), similar to Tailwind's utility approach but as plain CSS. Prefer composing multiple small classes in the HTML rather than writing large multi-property selectors.
+Example: .flex { display: flex } .gap-md { gap: var(--space-md) } .rounded { border-radius: var(--radius) }
+${TOKEN_RULES}`;
+
+const GENERAL_CSS_RULES = `
+CRITICAL CSS RULES — generate structured CSS with BEM-ish class naming.
+Write organized CSS with descriptive class names (e.g., .card, .card__header, .card--highlighted). Each selector groups all related properties together. Prefer semantic naming that describes the component structure.
+${TOKEN_RULES}`;
 
 const CHAT_FALLBACK = `
 

--- a/src/lib/settings-store.ts
+++ b/src/lib/settings-store.ts
@@ -1,0 +1,12 @@
+const CSS_STYLE_KEY = "cssp-settings-css-style";
+export type CssStyle = "tailwind" | "general";
+
+export function getCssStyle(): CssStyle {
+  const saved =
+    typeof window !== "undefined" ? localStorage.getItem(CSS_STYLE_KEY) : null;
+  return saved === "general" ? "general" : "tailwind";
+}
+
+export function setCssStyle(style: CssStyle): void {
+  localStorage.setItem(CSS_STYLE_KEY, style);
+}

--- a/src/lib/settings-store.ts
+++ b/src/lib/settings-store.ts
@@ -1,5 +1,26 @@
 const CSS_STYLE_KEY = "cssp-settings-css-style";
+const SHIKI_THEME_KEY = "cssp-settings-shiki-theme";
+
 export type CssStyle = "tailwind" | "general";
+
+export const SHIKI_THEMES = [
+  "vitesse-dark",
+  "vitesse-light",
+  "catppuccin-mocha",
+  "catppuccin-latte",
+  "dracula",
+  "github-dark",
+  "github-light",
+  "nord",
+  "one-dark-pro",
+  "solarized-dark",
+  "solarized-light",
+  "tokyo-night",
+  "min-dark",
+  "min-light",
+] as const;
+
+export type ShikiTheme = (typeof SHIKI_THEMES)[number];
 
 export function getCssStyle(): CssStyle {
   const saved =
@@ -10,5 +31,24 @@ export function getCssStyle(): CssStyle {
 export function setCssStyle(style: CssStyle): void {
   if (typeof window !== "undefined") {
     localStorage.setItem(CSS_STYLE_KEY, style);
+  }
+}
+
+export function getShikiTheme(): ShikiTheme {
+  const saved =
+    typeof window !== "undefined"
+      ? localStorage.getItem(SHIKI_THEME_KEY)
+      : null;
+  if (saved && (SHIKI_THEMES as readonly string[]).includes(saved)) {
+    return saved as ShikiTheme;
+  }
+  return "vitesse-dark";
+}
+
+export function setShikiTheme(theme: ShikiTheme): void {
+  if (typeof window !== "undefined") {
+    localStorage.setItem(SHIKI_THEME_KEY, theme);
+    // Notify components to re-highlight
+    window.dispatchEvent(new Event("cssp-shiki-theme-change"));
   }
 }

--- a/src/lib/settings-store.ts
+++ b/src/lib/settings-store.ts
@@ -8,5 +8,7 @@ export function getCssStyle(): CssStyle {
 }
 
 export function setCssStyle(style: CssStyle): void {
-  localStorage.setItem(CSS_STYLE_KEY, style);
+  if (typeof window !== "undefined") {
+    localStorage.setItem(CSS_STYLE_KEY, style);
+  }
 }

--- a/src/lib/token-panel-config.ts
+++ b/src/lib/token-panel-config.ts
@@ -120,6 +120,19 @@ export const demoPanelGroups: TokenGroup[] = [
     tokens: [{ variable: "--radius", label: "Radius", defaultValue: "8" }],
     sliderConfig: { unit: "px", min: 0, max: 24, step: 1 },
   },
+  {
+    id: "etc",
+    label: "Etc",
+    type: "slider",
+    tokens: [
+      {
+        variable: "--demo-padding",
+        label: "Demo Padding",
+        defaultValue: "16",
+      },
+    ],
+    sliderConfig: { unit: "px", min: 0, max: 64, step: 1 },
+  },
 ];
 
 /** Get all color-type groups */

--- a/src/pages/api/ai-chat.ts
+++ b/src/pages/api/ai-chat.ts
@@ -6,7 +6,8 @@ import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseAiResponse } from "../../lib/parse-ai-response";
-import { SYSTEM_PROMPT } from "../../lib/ai-system-prompt";
+import { getSystemPrompt } from "../../lib/ai-system-prompt";
+import type { CssStyle } from "../../lib/settings-store";
 import { jsonResponse } from "../../lib/api-utils";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -61,7 +62,8 @@ export const POST: APIRoute = async ({ request }) => {
   } catch {
     return jsonResponse({ error: "Invalid JSON" }, 400);
   }
-  const { message, history } = body;
+  const { message, history, cssStyle: rawCssStyle } = body;
+  const cssStyle: CssStyle = rawCssStyle === "general" ? "general" : "tailwind";
 
   if (typeof message !== "string" || !message.trim()) {
     return jsonResponse({ error: "message required" }, 400);
@@ -107,7 +109,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   inFlight = true;
   try {
-    const rawResponse = await callClaude(fullPrompt);
+    const rawResponse = await callClaude(fullPrompt, cssStyle);
     const result = parseAiResponse(rawResponse);
 
     if (result.action === "pending_files") {
@@ -134,7 +136,10 @@ export const POST: APIRoute = async ({ request }) => {
   }
 };
 
-async function callClaude(prompt: string): Promise<string> {
+async function callClaude(
+  prompt: string,
+  cssStyle: CssStyle = "tailwind",
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const proc = spawn(
       "claude",
@@ -145,7 +150,7 @@ async function callClaude(prompt: string): Promise<string> {
         "--max-budget-usd",
         "0.50",
         "--system-prompt",
-        SYSTEM_PROMPT,
+        getSystemPrompt(cssStyle),
       ],
       { stdio: ["pipe", "pipe", "pipe"] },
     );

--- a/src/pages/buttons.astro
+++ b/src/pages/buttons.astro
@@ -1,0 +1,358 @@
+---
+import BaseLayout from '../layouts/base-layout.astro';
+import HtmlPreview from '../components/html-preview.tsx';
+---
+
+<BaseLayout title="Buttons" activeCategory="buttons">
+  <h1 class="text-heading font-bold mb-vsp-lg">Button Patterns</h1>
+  <p class="text-body text-muted mb-vsp-xl">10 button variations built with strict design tokens.</p>
+  <div class="space-y-vsp-xl">
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">1. Primary Button</h2>
+      <HtmlPreview client:visible title="Primary Button" html={`<button class="btn btn-primary">Click me</button>`} css={`.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--vsp-sm) var(--hsp-md);
+  border: none;
+  border-radius: var(--radius);
+  font-size: var(--font-md);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-primary {
+  background-color: var(--accent);
+  color: white;
+}
+
+.btn-primary:hover {
+  background-color: var(--accent-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow);
+}
+
+.btn-primary:active {
+  transform: translateY(0);
+}
+
+.btn-primary:focus-visible {
+  outline: var(--focus-ring);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">2. Secondary Button</h2>
+      <HtmlPreview client:visible title="Secondary Button" html={`<button class="btn btn-secondary">Secondary</button>`} css={`.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--vsp-sm) var(--hsp-md);
+  border: none;
+  border-radius: var(--radius);
+  font-size: var(--font-md);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-secondary {
+  background-color: var(--bg-subtle);
+  color: var(--fg);
+  border: 1px solid var(--border);
+}
+
+.btn-secondary:hover {
+  background-color: var(--border);
+  color: var(--fg);
+}
+
+.btn-secondary:focus-visible {
+  outline: var(--focus-ring);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">3. Outlined Button</h2>
+      <HtmlPreview client:visible title="Outlined Button" html={`<button class="btn btn-outline">Outline</button>`} css={`.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--vsp-sm) var(--hsp-md);
+  border: none;
+  border-radius: var(--radius);
+  font-size: var(--font-md);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-outline {
+  background-color: transparent;
+  color: var(--accent);
+  border: 2px solid var(--accent);
+}
+
+.btn-outline:hover {
+  background-color: var(--accent);
+  color: white;
+}
+
+.btn-outline:focus-visible {
+  outline: var(--focus-ring);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">4. Ghost Button</h2>
+      <HtmlPreview client:visible title="Ghost Button" html={`<button class="btn btn-ghost">Ghost</button>`} css={`.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--vsp-sm) var(--hsp-md);
+  border: none;
+  border-radius: var(--radius);
+  font-size: var(--font-md);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-ghost {
+  background-color: transparent;
+  color: var(--accent);
+  border: none;
+}
+
+.btn-ghost:hover {
+  background-color: rgba(var(--accent-rgb), 0.1);
+  color: var(--accent-hover);
+}
+
+.btn-ghost:focus-visible {
+  outline: var(--focus-ring);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">5. Danger Button</h2>
+      <HtmlPreview client:visible title="Danger Button" html={`<button class="btn btn-danger">Delete</button>`} css={`.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--vsp-sm) var(--hsp-md);
+  border: none;
+  border-radius: var(--radius);
+  font-size: var(--font-md);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-danger {
+  background-color: var(--danger);
+  color: white;
+}
+
+.btn-danger:hover {
+  opacity: 0.9;
+  box-shadow: var(--shadow);
+}
+
+.btn-danger:focus-visible {
+  outline: var(--focus-ring);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">6. Success Button</h2>
+      <HtmlPreview client:visible title="Success Button" html={`<button class="btn btn-success">Confirm</button>`} css={`.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--vsp-sm) var(--hsp-md);
+  border: none;
+  border-radius: var(--radius);
+  font-size: var(--font-md);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-success {
+  background-color: var(--success);
+  color: white;
+}
+
+.btn-success:hover {
+  opacity: 0.9;
+  box-shadow: var(--shadow);
+}
+
+.btn-success:focus-visible {
+  outline: var(--focus-ring);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">7. Large Button</h2>
+      <HtmlPreview client:visible title="Large Button" html={`<button class="btn btn-primary btn-lg">Large Button</button>`} css={`.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--vsp-sm) var(--hsp-md);
+  border: none;
+  border-radius: var(--radius);
+  font-size: var(--font-md);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-primary {
+  background-color: var(--accent);
+  color: white;
+}
+
+.btn-primary:hover {
+  background-color: var(--accent-hover);
+}
+
+.btn-lg {
+  padding: var(--vsp-md) var(--hsp-lg);
+  font-size: var(--font-lg);
+}
+
+.btn-primary:focus-visible {
+  outline: var(--focus-ring);
+}`} height={80} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">8. Small Button</h2>
+      <HtmlPreview client:visible title="Small Button" html={`<button class="btn btn-primary btn-sm">Small</button>`} css={`.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--vsp-sm) var(--hsp-md);
+  border: none;
+  border-radius: var(--radius);
+  font-size: var(--font-md);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-primary {
+  background-color: var(--accent);
+  color: white;
+}
+
+.btn-primary:hover {
+  background-color: var(--accent-hover);
+}
+
+.btn-sm {
+  padding: var(--vsp-xs) var(--hsp-sm);
+  font-size: var(--font-sm);
+}
+
+.btn-primary:focus-visible {
+  outline: var(--focus-ring);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">9. Icon Button</h2>
+      <HtmlPreview client:visible title="Icon Button" html={`<button class="btn btn-icon" aria-label="Confirm">✓</button>`} css={`.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--vsp-sm) var(--hsp-md);
+  border: none;
+  border-radius: var(--radius);
+  font-size: var(--font-md);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-icon {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 50%;
+  background-color: var(--accent);
+  color: white;
+  font-size: var(--font-lg);
+}
+
+.btn-icon:hover {
+  background-color: var(--accent-hover);
+  box-shadow: var(--shadow);
+}
+
+.btn-icon:focus-visible {
+  outline: var(--focus-ring);
+}`} height={80} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">10. Button Group</h2>
+      <HtmlPreview client:visible title="Button Group" html={`<div class="btn-group">
+  <button class="btn btn-group-item">Left</button>
+  <button class="btn btn-group-item">Middle</button>
+  <button class="btn btn-group-item">Right</button>
+</div>`} css={`.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--vsp-sm) var(--hsp-md);
+  border: none;
+  border-radius: var(--radius);
+  font-size: var(--font-md);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-group {
+  display: inline-flex;
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.btn-group-item {
+  background-color: var(--bg);
+  color: var(--fg);
+  border: none;
+  border-radius: 0;
+  border-right: 1px solid var(--border);
+}
+
+.btn-group-item:last-child {
+  border-right: none;
+}
+
+.btn-group-item:hover {
+  background-color: var(--bg-subtle);
+}
+
+.btn-group-item:focus-visible {
+  outline: var(--focus-ring);
+}`} height={60} />
+    </section>
+  </div>
+</BaseLayout>

--- a/src/pages/header-menus.astro
+++ b/src/pages/header-menus.astro
@@ -1,0 +1,689 @@
+---
+import BaseLayout from '../layouts/base-layout.astro';
+import HtmlPreview from '../components/html-preview.tsx';
+---
+
+<BaseLayout title="Header Menus" activeCategory="header-menus">
+  <h1 class="text-heading font-bold mb-vsp-lg">Header Menu Patterns</h1>
+  <p class="text-body text-muted mb-vsp-xl">10 variations built with strict design tokens.</p>
+  <div class="space-y-vsp-xl">
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">1. Basic Horizontal Nav</h2>
+      <HtmlPreview client:visible title="Basic Horizontal Nav" html={`<header class="nav-header-1">
+  <div class="nav-container-1">
+    <div class="nav-logo-1">Logo</div>
+    <nav class="nav-menu-1">
+      <a href="#" class="nav-link-1">Home</a>
+      <a href="#" class="nav-link-1">About</a>
+      <a href="#" class="nav-link-1">Services</a>
+      <a href="#" class="nav-link-1">Contact</a>
+    </nav>
+  </div>
+</header>`} css={`.nav-header-1 {
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding: var(--space-sm) 0;
+}
+
+.nav-container-1 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav-logo-1 {
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: var(--fg);
+}
+
+.nav-menu-1 {
+  display: flex;
+  gap: var(--space-md);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-link-1 {
+  color: var(--fg);
+  text-decoration: none;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius);
+  transition: all 0.2s ease;
+}
+
+.nav-link-1:hover {
+  color: var(--accent);
+  background: var(--bg-subtle);
+}
+
+.nav-link-1:focus-visible {
+  outline: var(--focus-ring);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">2. Sticky Header with Shadow</h2>
+      <HtmlPreview client:visible title="Sticky Header with Shadow" html={`<header class="nav-header-2">
+  <div class="nav-container-2">
+    <div class="nav-logo-2">Brand</div>
+    <nav class="nav-menu-2">
+      <a href="#" class="nav-link-2">Products</a>
+      <a href="#" class="nav-link-2">Docs</a>
+      <a href="#" class="nav-link-2">Pricing</a>
+      <a href="#" class="nav-link-2 nav-cta-2">Sign Up</a>
+    </nav>
+  </div>
+</header>`} css={`.nav-header-2 {
+  background: var(--bg);
+  padding: var(--space-md) 0;
+  box-shadow: var(--shadow);
+  position: relative;
+  z-index: 10;
+}
+
+.nav-container-2 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav-logo-2 {
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: var(--accent);
+  letter-spacing: -0.5px;
+}
+
+.nav-menu-2 {
+  display: flex;
+  gap: var(--space-lg);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+}
+
+.nav-link-2 {
+  color: var(--fg);
+  text-decoration: none;
+  font-size: var(--font-sm);
+  transition: color 0.2s ease;
+}
+
+.nav-link-2:hover {
+  color: var(--accent);
+}
+
+.nav-cta-2 {
+  background: var(--accent);
+  color: var(--bg);
+  padding: var(--space-xs) var(--space-md);
+  border-radius: var(--radius);
+}
+
+.nav-cta-2:hover {
+  color: var(--bg);
+  background: var(--accent-hover);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">3. Centered Logo with Underline</h2>
+      <HtmlPreview client:visible title="Centered Logo with Underline" html={`<header class="nav-header-3">
+  <div class="nav-container-3">
+    <div class="nav-logo-3">Logo</div>
+    <nav class="nav-menu-3">
+      <a href="#" class="nav-link-3">Home</a>
+      <a href="#" class="nav-link-3 nav-active-3">Services</a>
+      <a href="#" class="nav-link-3">About</a>
+      <a href="#" class="nav-link-3">Contact</a>
+    </nav>
+  </div>
+</header>`} css={`.nav-header-3 {
+  background: var(--bg);
+  padding: var(--space-sm) 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-container-3 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+  text-align: center;
+}
+
+.nav-logo-3 {
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: var(--fg);
+  margin-bottom: var(--space-md);
+  display: block;
+}
+
+.nav-menu-3 {
+  display: flex;
+  gap: var(--space-lg);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  justify-content: center;
+}
+
+.nav-link-3 {
+  color: var(--fg-muted);
+  text-decoration: none;
+  padding: var(--space-xs) 0;
+  border-bottom: 2px solid transparent;
+  transition: all 0.2s ease;
+  font-size: var(--font-sm);
+}
+
+.nav-link-3:hover {
+  color: var(--fg);
+  border-bottom-color: var(--accent);
+}
+
+.nav-active-3 {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}`} height={80} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">4. Dark Theme Header</h2>
+      <HtmlPreview client:visible title="Dark Theme Header" html={`<header class="nav-header-4">
+  <div class="nav-container-4">
+    <div class="nav-logo-4">Dev</div>
+    <nav class="nav-menu-4">
+      <a href="#" class="nav-link-4">Code</a>
+      <a href="#" class="nav-link-4">Deploy</a>
+      <a href="#" class="nav-link-4">Monitor</a>
+      <a href="#" class="nav-link-4">Docs</a>
+    </nav>
+  </div>
+</header>`} css={`.nav-header-4 {
+  background: #1a1a1a;
+  padding: var(--space-md) 0;
+  border-bottom: 1px solid #333;
+}
+
+.nav-container-4 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav-logo-4 {
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: var(--accent);
+}
+
+.nav-menu-4 {
+  display: flex;
+  gap: var(--space-md);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-link-4 {
+  color: #ccc;
+  text-decoration: none;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius);
+  transition: all 0.2s ease;
+  font-size: var(--font-sm);
+}
+
+.nav-link-4:hover {
+  color: var(--accent);
+  background: #333;
+}
+
+.nav-link-4:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">5. Minimal with Pills</h2>
+      <HtmlPreview client:visible title="Minimal with Pills" html={`<header class="nav-header-5">
+  <div class="nav-container-5">
+    <div class="nav-logo-5">St</div>
+    <nav class="nav-menu-5">
+      <a href="#" class="nav-link-5">Updates</a>
+      <a href="#" class="nav-link-5 nav-active-5">Features</a>
+      <a href="#" class="nav-link-5">Help</a>
+    </nav>
+  </div>
+</header>`} css={`.nav-header-5 {
+  background: var(--bg);
+  padding: var(--space-sm) 0;
+}
+
+.nav-container-5 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav-logo-5 {
+  font-size: var(--font-md);
+  font-weight: bold;
+  color: var(--fg);
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent);
+  color: var(--bg);
+  border-radius: 50%;
+}
+
+.nav-menu-5 {
+  display: flex;
+  gap: var(--space-sm);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-link-5 {
+  color: var(--fg-muted);
+  text-decoration: none;
+  padding: var(--space-xs) var(--space-md);
+  border-radius: 20px;
+  transition: all 0.2s ease;
+  font-size: var(--font-sm);
+}
+
+.nav-link-5:hover {
+  background: var(--bg-subtle);
+  color: var(--fg);
+}
+
+.nav-active-5 {
+  background: var(--accent);
+  color: var(--bg);
+}
+
+.nav-active-5:hover {
+  background: var(--accent-hover);
+  color: var(--bg);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">6. Two-Row with Tagline</h2>
+      <HtmlPreview client:visible title="Two-Row with Tagline" html={`<header class="nav-header-6">
+  <div class="nav-container-6 nav-top-6">
+    <div class="nav-branding-6">
+      <div class="nav-logo-6">Company</div>
+      <div class="nav-tagline-6">Build better</div>
+    </div>
+    <div class="nav-util-6">Support</div>
+  </div>
+  <nav class="nav-bottom-6">
+    <a href="#" class="nav-link-6">Solutions</a>
+    <a href="#" class="nav-link-6">Partners</a>
+    <a href="#" class="nav-link-6">Community</a>
+    <a href="#" class="nav-link-6">Blog</a>
+  </nav>
+</header>`} css={`.nav-header-6 {
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-container-6 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+}
+
+.nav-top-6 {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-md) 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-branding-6 {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.nav-logo-6 {
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: var(--fg);
+}
+
+.nav-tagline-6 {
+  font-size: var(--font-sm);
+  color: var(--fg-muted);
+}
+
+.nav-util-6 {
+  color: var(--fg-muted);
+  font-size: var(--font-sm);
+}
+
+.nav-bottom-6 {
+  display: flex;
+  gap: var(--space-md);
+  padding: var(--space-sm) 0;
+  list-style: none;
+  margin: 0;
+}
+
+.nav-link-6 {
+  color: var(--fg);
+  text-decoration: none;
+  font-size: var(--font-sm);
+  transition: color 0.2s ease;
+}
+
+.nav-link-6:hover {
+  color: var(--accent);
+}`} height={90} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">7. Full Width with Spacing</h2>
+      <HtmlPreview client:visible title="Full Width with Spacing" html={`<header class="nav-header-7">
+  <nav class="nav-container-7">
+    <a href="#" class="nav-logo-7">◆ Design</a>
+    <div class="nav-menu-7">
+      <a href="#" class="nav-link-7">Components</a>
+      <a href="#" class="nav-link-7">Tokens</a>
+      <a href="#" class="nav-link-7">Guidelines</a>
+    </div>
+    <button class="nav-btn-7">Get Started</button>
+  </nav>
+</header>`} css={`.nav-header-7 {
+  background: var(--bg);
+  padding: var(--space-md) 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-container-7 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-lg);
+}
+
+.nav-logo-7 {
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: var(--fg);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.nav-menu-7 {
+  display: flex;
+  gap: var(--space-lg);
+  flex: 1;
+  margin-left: var(--space-lg);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-link-7 {
+  color: var(--fg-muted);
+  text-decoration: none;
+  font-size: var(--font-sm);
+  transition: color 0.2s ease;
+}
+
+.nav-link-7:hover {
+  color: var(--accent);
+}
+
+.nav-btn-7 {
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  padding: var(--space-xs) var(--space-lg);
+  border-radius: var(--radius);
+  font-size: var(--font-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.nav-btn-7:hover {
+  background: var(--accent-hover);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">8. Underline Nav with Icons</h2>
+      <HtmlPreview client:visible title="Underline Nav with Icons" html={`<header class="nav-header-8">
+  <div class="nav-container-8">
+    <div class="nav-logo-8">UI Kit</div>
+    <nav class="nav-menu-8">
+      <a href="#" class="nav-link-8" title="Home">🏠</a>
+      <a href="#" class="nav-link-8 nav-active-8" title="Components">🎨</a>
+      <a href="#" class="nav-link-8" title="Settings">⚙️</a>
+      <a href="#" class="nav-link-8" title="Help">❓</a>
+    </nav>
+  </div>
+</header>`} css={`.nav-header-8 {
+  background: var(--bg);
+  border-bottom: 2px solid var(--border);
+  padding: var(--space-md) 0;
+}
+
+.nav-container-8 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav-logo-8 {
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: var(--fg);
+}
+
+.nav-menu-8 {
+  display: flex;
+  gap: var(--space-md);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+}
+
+.nav-link-8 {
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius);
+  text-decoration: none;
+  transition: all 0.2s ease;
+  border-bottom: 3px solid transparent;
+}
+
+.nav-link-8:hover {
+  background: var(--bg-subtle);
+}
+
+.nav-active-8 {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}`} height={60} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">9. Gradient Accent Bar</h2>
+      <HtmlPreview client:visible title="Gradient Accent Bar" html={`<header class="nav-header-9">
+  <div class="nav-container-9">
+    <div class="nav-logo-9">Studio</div>
+    <nav class="nav-menu-9">
+      <a href="#" class="nav-link-9">Work</a>
+      <a href="#" class="nav-link-9">About</a>
+      <a href="#" class="nav-link-9">Contact</a>
+    </nav>
+  </div>
+  <div class="nav-accent-9"></div>
+</header>`} css={`.nav-header-9 {
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-container-9 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--space-md);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav-logo-9 {
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: var(--fg);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.nav-menu-9 {
+  display: flex;
+  gap: var(--space-lg);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-link-9 {
+  color: var(--fg);
+  text-decoration: none;
+  font-size: var(--font-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  transition: color 0.2s ease;
+}
+
+.nav-link-9:hover {
+  color: var(--accent);
+}
+
+.nav-accent-9 {
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), var(--info), var(--accent));
+}`} height={75} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">10. Search & Nav Combined</h2>
+      <HtmlPreview client:visible title="Search & Nav Combined" html={`<header class="nav-header-10">
+  <div class="nav-container-10">
+    <div class="nav-logo-10">Search UI</div>
+    <div class="nav-search-10">
+      <input type="text" placeholder="Search..." class="nav-search-input-10">
+    </div>
+    <nav class="nav-menu-10">
+      <a href="#" class="nav-link-10">Filters</a>
+      <a href="#" class="nav-link-10">Sort</a>
+    </nav>
+  </div>
+</header>`} css={`.nav-header-10 {
+  background: var(--bg);
+  padding: var(--space-md) 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-container-10 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.nav-logo-10 {
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: var(--fg);
+  white-space: nowrap;
+}
+
+.nav-search-10 {
+  flex: 1;
+  min-width: 200px;
+}
+
+.nav-search-input-10 {
+  width: 100%;
+  padding: var(--space-xs) var(--space-sm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-subtle);
+  color: var(--fg);
+  font-size: var(--font-sm);
+  transition: all 0.2s ease;
+}
+
+.nav-search-input-10:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--bg);
+}
+
+.nav-menu-10 {
+  display: flex;
+  gap: var(--space-md);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-link-10 {
+  color: var(--fg-muted);
+  text-decoration: none;
+  font-size: var(--font-sm);
+  transition: color 0.2s ease;
+  white-space: nowrap;
+}
+
+.nav-link-10:hover {
+  color: var(--accent);
+}`} height={60} />
+    </section>
+  </div>
+</BaseLayout>

--- a/src/pages/tab-menus.astro
+++ b/src/pages/tab-menus.astro
@@ -1,0 +1,746 @@
+---
+import BaseLayout from '../layouts/base-layout.astro';
+import HtmlPreview from '../components/html-preview.tsx';
+---
+
+<BaseLayout title="Tab Menus" activeCategory="tab-menus">
+  <h1 class="text-heading font-bold mb-vsp-lg">Tab Menu Patterns</h1>
+  <p class="text-body text-muted mb-vsp-xl">10 variations built with strict design tokens.</p>
+  <div class="space-y-vsp-xl">
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">1. Underline Tabs</h2>
+      <HtmlPreview client:visible title="Underline Tabs" html={`<div class="tabs-ul">
+  <input type="radio" id="tab1-1" name="tabs1" value="tab1" checked>
+  <input type="radio" id="tab1-2" name="tabs1" value="tab2">
+  <input type="radio" id="tab1-3" name="tabs1" value="tab3">
+  <div class="tabs-labels">
+    <label for="tab1-1" class="tab-label">Overview</label>
+    <label for="tab1-2" class="tab-label">Details</label>
+    <label for="tab1-3" class="tab-label">Settings</label>
+  </div>
+  <div class="tabs-indicator"></div>
+  <div class="tabs-content">
+    <div class="tab-pane">Overview content goes here</div>
+    <div class="tab-pane">Details content goes here</div>
+    <div class="tab-pane">Settings content goes here</div>
+  </div>
+</div>`} css={`.tabs-ul {
+  position: relative;
+}
+
+.tabs-ul input {
+  display: none;
+}
+
+.tabs-labels {
+  display: flex;
+  gap: var(--space-md);
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+
+.tab-label {
+  padding: var(--space-sm) 0;
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: var(--font-md);
+  transition: color 200ms;
+  user-select: none;
+}
+
+.tab-label:hover {
+  color: var(--fg);
+}
+
+#tab1-1:checked ~ .tabs-labels > [for="tab1-1"],
+#tab1-2:checked ~ .tabs-labels > [for="tab1-2"],
+#tab1-3:checked ~ .tabs-labels > [for="tab1-3"] {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.tabs-indicator {
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  background: var(--accent);
+  width: calc(100% / 3);
+  transition: transform 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+#tab1-2:checked ~ .tabs-indicator {
+  transform: translateX(100%);
+}
+
+#tab1-3:checked ~ .tabs-indicator {
+  transform: translateX(200%);
+}
+
+.tabs-content {
+  padding: var(--space-lg) 0;
+}
+
+.tab-pane {
+  display: none;
+  font-size: var(--font-md);
+}
+
+#tab1-1:checked ~ .tabs-content > :nth-child(1),
+#tab1-2:checked ~ .tabs-content > :nth-child(2),
+#tab1-3:checked ~ .tabs-content > :nth-child(3) {
+  display: block;
+}`} height={160} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">2. Pills/Rounded Tabs</h2>
+      <HtmlPreview client:visible title="Pills Tabs" html={`<div class="tabs-pills">
+  <input type="radio" id="tab2-1" name="tabs2" checked>
+  <input type="radio" id="tab2-2" name="tabs2">
+  <input type="radio" id="tab2-3" name="tabs2">
+  <div class="pills-container">
+    <label for="tab2-1" class="pill">Dashboard</label>
+    <label for="tab2-2" class="pill">Analytics</label>
+    <label for="tab2-3" class="pill">Reports</label>
+  </div>
+  <div class="pills-content">
+    <div class="pill-pane">Dashboard widgets and overview</div>
+    <div class="pill-pane">Analytics charts and metrics</div>
+    <div class="pill-pane">Reports and exports</div>
+  </div>
+</div>`} css={`.tabs-pills input {
+  display: none;
+}
+
+.pills-container {
+  display: flex;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
+  flex-wrap: wrap;
+}
+
+.pill {
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-subtle);
+  color: var(--fg-muted);
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: var(--font-md);
+  transition: all 200ms;
+  border: 1px solid transparent;
+}
+
+.pill:hover {
+  background: var(--bg);
+  color: var(--fg);
+}
+
+#tab2-1:checked ~ .pills-container > [for="tab2-1"],
+#tab2-2:checked ~ .pills-container > [for="tab2-2"],
+#tab2-3:checked ~ .pills-container > [for="tab2-3"] {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+.pills-content {
+  padding: var(--space-md);
+  border-radius: var(--radius);
+  background: var(--bg-subtle);
+}
+
+.pill-pane {
+  display: none;
+  font-size: var(--font-md);
+}
+
+#tab2-1:checked ~ .pills-content > :nth-child(1),
+#tab2-2:checked ~ .pills-content > :nth-child(2),
+#tab2-3:checked ~ .pills-content > :nth-child(3) {
+  display: block;
+}`} height={140} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">3. Icon + Text Tabs</h2>
+      <HtmlPreview client:visible title="Icon Tabs" html={`<div class="tabs-icon">
+  <input type="radio" id="tab3-1" name="tabs3" checked>
+  <input type="radio" id="tab3-2" name="tabs3">
+  <input type="radio" id="tab3-3" name="tabs3">
+  <div class="icon-tabs-nav">
+    <label for="tab3-1" class="icon-tab"><span class="tab-icon">🏠</span> Home</label>
+    <label for="tab3-2" class="icon-tab"><span class="tab-icon">❤️</span> Likes</label>
+    <label for="tab3-3" class="icon-tab"><span class="tab-icon">⚙️</span> Config</label>
+  </div>
+  <div class="icon-tabs-panes">
+    <div class="icon-pane">Home feed and timeline</div>
+    <div class="icon-pane">Your liked items</div>
+    <div class="icon-pane">Configuration options</div>
+  </div>
+</div>`} css={`.tabs-icon input {
+  display: none;
+}
+
+.icon-tabs-nav {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.icon-tab {
+  flex: 1;
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: var(--font-md);
+  transition: all 200ms;
+  border-bottom: 3px solid transparent;
+  text-align: center;
+}
+
+.tab-icon {
+  font-size: 1.5rem;
+}
+
+.icon-tab:hover {
+  background: var(--bg-subtle);
+  color: var(--fg);
+}
+
+#tab3-1:checked ~ .icon-tabs-nav > [for="tab3-1"],
+#tab3-2:checked ~ .icon-tabs-nav > [for="tab3-2"],
+#tab3-3:checked ~ .icon-tabs-nav > [for="tab3-3"] {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.icon-tabs-panes {
+  padding: var(--space-lg);
+}
+
+.icon-pane {
+  display: none;
+  font-size: var(--font-md);
+}
+
+#tab3-1:checked ~ .icon-tabs-panes > :nth-child(1),
+#tab3-2:checked ~ .icon-tabs-panes > :nth-child(2),
+#tab3-3:checked ~ .icon-tabs-panes > :nth-child(3) {
+  display: block;
+}`} height={160} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">4. Vertical Tabs</h2>
+      <HtmlPreview client:visible title="Vertical Tabs" html={`<div class="tabs-vertical" style="display: flex; gap: 2rem;">
+  <input type="radio" id="tab4-1" name="tabs4" checked>
+  <input type="radio" id="tab4-2" name="tabs4">
+  <input type="radio" id="tab4-3" name="tabs4">
+  <div class="vert-nav">
+    <label for="tab4-1" class="vert-tab">Profile</label>
+    <label for="tab4-2" class="vert-tab">Security</label>
+    <label for="tab4-3" class="vert-tab">Billing</label>
+  </div>
+  <div class="vert-content">
+    <div class="vert-pane">User profile information</div>
+    <div class="vert-pane">Security settings</div>
+    <div class="vert-pane">Billing & subscription</div>
+  </div>
+</div>`} css={`.tabs-vertical input {
+  display: none;
+}
+
+.vert-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border-right: 1px solid var(--border);
+  min-width: 120px;
+}
+
+.vert-tab {
+  padding: var(--space-md) var(--space-lg);
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: var(--font-md);
+  transition: all 200ms;
+  border-right: 3px solid transparent;
+  white-space: nowrap;
+}
+
+.vert-tab:hover {
+  background: var(--bg-subtle);
+  color: var(--fg);
+}
+
+#tab4-1:checked ~ .vert-nav > [for="tab4-1"],
+#tab4-2:checked ~ .vert-nav > [for="tab4-2"],
+#tab4-3:checked ~ .vert-nav > [for="tab4-3"] {
+  color: var(--accent);
+  border-right-color: var(--accent);
+  background: var(--bg-subtle);
+}
+
+.vert-content {
+  flex: 1;
+  padding: var(--space-lg);
+}
+
+.vert-pane {
+  display: none;
+  font-size: var(--font-md);
+  line-height: 1.6;
+}
+
+#tab4-1:checked ~ .vert-content > :nth-child(1),
+#tab4-2:checked ~ .vert-content > :nth-child(2),
+#tab4-3:checked ~ .vert-content > :nth-child(3) {
+  display: block;
+}`} height={160} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">5. Segmented Control</h2>
+      <HtmlPreview client:visible title="Segmented Control" html={`<div class="tabs-segmented">
+  <input type="radio" id="tab5-1" name="tabs5" checked>
+  <input type="radio" id="tab5-2" name="tabs5">
+  <input type="radio" id="tab5-3" name="tabs5">
+  <div class="segment-group">
+    <label for="tab5-1" class="segment">List</label>
+    <label for="tab5-2" class="segment">Grid</label>
+    <label for="tab5-3" class="segment">Cards</label>
+  </div>
+  <div class="segment-content">
+    <div class="seg-pane">List view content</div>
+    <div class="seg-pane">Grid view content</div>
+    <div class="seg-pane">Card view content</div>
+  </div>
+</div>`} css={`.tabs-segmented input {
+  display: none;
+}
+
+.segment-group {
+  display: inline-flex;
+  gap: 0;
+  background: var(--bg-subtle);
+  border-radius: var(--radius);
+  padding: 2px;
+  margin-bottom: var(--space-lg);
+}
+
+.segment {
+  flex: 1;
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  color: var(--fg-muted);
+  background: transparent;
+  font-size: var(--font-md);
+  transition: all 200ms;
+  border-radius: calc(var(--radius) - 2px);
+  text-align: center;
+  min-width: 80px;
+}
+
+.segment:hover {
+  color: var(--fg);
+}
+
+#tab5-1:checked ~ .segment-group > [for="tab5-1"],
+#tab5-2:checked ~ .segment-group > [for="tab5-2"],
+#tab5-3:checked ~ .segment-group > [for="tab5-3"] {
+  background: var(--accent);
+  color: white;
+  font-weight: 600;
+}
+
+.segment-content {
+  padding: var(--space-lg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.seg-pane {
+  display: none;
+  font-size: var(--font-md);
+}
+
+#tab5-1:checked ~ .segment-content > :nth-child(1),
+#tab5-2:checked ~ .segment-content > :nth-child(2),
+#tab5-3:checked ~ .segment-content > :nth-child(3) {
+  display: block;
+}`} height={140} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">6. Tabs with Badge Indicators</h2>
+      <HtmlPreview client:visible title="Tabs with Badges" html={`<div class="tabs-badge">
+  <input type="radio" id="tab6-1" name="tabs6" checked>
+  <input type="radio" id="tab6-2" name="tabs6">
+  <input type="radio" id="tab6-3" name="tabs6">
+  <div class="badge-nav">
+    <label for="tab6-1" class="badge-tab">Inbox <span class="badge">5</span></label>
+    <label for="tab6-2" class="badge-tab">Archive <span class="badge" style="background: var(--success);">12</span></label>
+    <label for="tab6-3" class="badge-tab">Spam</label>
+  </div>
+  <div class="badge-content">
+    <div class="badge-pane">5 unread messages</div>
+    <div class="badge-pane">12 archived items</div>
+    <div class="badge-pane">No spam detected</div>
+  </div>
+</div>`} css={`.tabs-badge input {
+  display: none;
+}
+
+.badge-nav {
+  display: flex;
+  gap: var(--space-md);
+  border-bottom: 1px solid var(--border);
+}
+
+.badge-tab {
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: var(--font-md);
+  transition: color 200ms;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.badge {
+  background: var(--danger);
+  color: white;
+  padding: 0 6px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  min-width: 20px;
+  text-align: center;
+}
+
+.badge-tab:hover {
+  color: var(--fg);
+}
+
+#tab6-1:checked ~ .badge-nav > [for="tab6-1"],
+#tab6-2:checked ~ .badge-nav > [for="tab6-2"],
+#tab6-3:checked ~ .badge-nav > [for="tab6-3"] {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+#tab6-1:checked ~ .badge-nav > [for="tab6-1"]::after,
+#tab6-2:checked ~ .badge-nav > [for="tab6-2"]::after,
+#tab6-3:checked ~ .badge-nav > [for="tab6-3"]::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--accent);
+}
+
+.badge-content {
+  padding: var(--space-lg) 0;
+}
+
+.badge-pane {
+  display: none;
+  font-size: var(--font-md);
+}
+
+#tab6-1:checked ~ .badge-content > :nth-child(1),
+#tab6-2:checked ~ .badge-content > :nth-child(2),
+#tab6-3:checked ~ .badge-content > :nth-child(3) {
+  display: block;
+}`} height={140} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">7. Filled Background Tabs</h2>
+      <HtmlPreview client:visible title="Filled Tabs" html={`<div class="tabs-filled">
+  <input type="radio" id="tab7-1" name="tabs7" checked>
+  <input type="radio" id="tab7-2" name="tabs7">
+  <input type="radio" id="tab7-3" name="tabs7">
+  <div class="filled-nav">
+    <label for="tab7-1" class="filled-tab">About</label>
+    <label for="tab7-2" class="filled-tab">Team</label>
+    <label for="tab7-3" class="filled-tab">Contact</label>
+  </div>
+  <div class="filled-content">
+    <div class="filled-pane">Company information</div>
+    <div class="filled-pane">Team members</div>
+    <div class="filled-pane">Get in touch</div>
+  </div>
+</div>`} css={`.tabs-filled input {
+  display: none;
+}
+
+.filled-nav {
+  display: flex;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-lg);
+}
+
+.filled-tab {
+  padding: var(--space-sm) var(--space-lg);
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: var(--font-md);
+  background: var(--bg-subtle);
+  border-radius: var(--radius);
+  transition: all 200ms;
+}
+
+.filled-tab:hover {
+  background: var(--border);
+  color: var(--fg);
+}
+
+#tab7-1:checked ~ .filled-nav > [for="tab7-1"],
+#tab7-2:checked ~ .filled-nav > [for="tab7-2"],
+#tab7-3:checked ~ .filled-nav > [for="tab7-3"] {
+  background: var(--accent);
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.filled-content {
+  padding: var(--space-lg);
+}
+
+.filled-pane {
+  display: none;
+  font-size: var(--font-md);
+}
+
+#tab7-1:checked ~ .filled-content > :nth-child(1),
+#tab7-2:checked ~ .filled-content > :nth-child(2),
+#tab7-3:checked ~ .filled-content > :nth-child(3) {
+  display: block;
+}`} height={140} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">8. Outlined/Bordered Tabs</h2>
+      <HtmlPreview client:visible title="Outlined Tabs" html={`<div class="tabs-outlined">
+  <input type="radio" id="tab8-1" name="tabs8" checked>
+  <input type="radio" id="tab8-2" name="tabs8">
+  <input type="radio" id="tab8-3" name="tabs8">
+  <div class="outlined-nav">
+    <label for="tab8-1" class="outlined-tab">Code</label>
+    <label for="tab8-2" class="outlined-tab">Preview</label>
+    <label for="tab8-3" class="outlined-tab">Tests</label>
+  </div>
+  <div class="outlined-content">
+    <div class="outlined-pane">Code editor view</div>
+    <div class="outlined-pane">Live preview</div>
+    <div class="outlined-pane">Test results</div>
+  </div>
+</div>`} css={`.tabs-outlined input {
+  display: none;
+}
+
+.outlined-nav {
+  display: flex;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
+}
+
+.outlined-tab {
+  padding: var(--space-sm) var(--space-lg);
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: var(--font-md);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: all 200ms;
+}
+
+.outlined-tab:hover {
+  border-color: var(--fg);
+  color: var(--fg);
+  background: var(--bg-subtle);
+}
+
+#tab8-1:checked ~ .outlined-nav > [for="tab8-1"],
+#tab8-2:checked ~ .outlined-nav > [for="tab8-2"],
+#tab8-3:checked ~ .outlined-nav > [for="tab8-3"] {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+  font-weight: 600;
+}
+
+.outlined-content {
+  padding: var(--space-lg);
+}
+
+.outlined-pane {
+  display: none;
+  font-size: var(--font-md);
+}
+
+#tab8-1:checked ~ .outlined-content > :nth-child(1),
+#tab8-2:checked ~ .outlined-content > :nth-child(2),
+#tab8-3:checked ~ .outlined-content > :nth-child(3) {
+  display: block;
+}`} height={140} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">9. Full-Width Tabs</h2>
+      <HtmlPreview client:visible title="Full-Width Tabs" html={`<div class="tabs-fullwidth">
+  <input type="radio" id="tab9-1" name="tabs9" checked>
+  <input type="radio" id="tab9-2" name="tabs9">
+  <input type="radio" id="tab9-3" name="tabs9">
+  <div class="fw-nav">
+    <label for="tab9-1" class="fw-tab">Option 1</label>
+    <label for="tab9-2" class="fw-tab">Option 2</label>
+    <label for="tab9-3" class="fw-tab">Option 3</label>
+  </div>
+  <div class="fw-content">
+    <div class="fw-pane">First option content</div>
+    <div class="fw-pane">Second option content</div>
+    <div class="fw-pane">Third option content</div>
+  </div>
+</div>`} css={`.tabs-fullwidth input {
+  display: none;
+}
+
+.fw-nav {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.fw-tab {
+  flex: 1;
+  padding: var(--space-md);
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: var(--font-md);
+  text-align: center;
+  background: transparent;
+  border-bottom: 3px solid transparent;
+  transition: all 200ms;
+}
+
+.fw-tab:hover {
+  background: var(--bg-subtle);
+  color: var(--fg);
+}
+
+#tab9-1:checked ~ .fw-nav > [for="tab9-1"],
+#tab9-2:checked ~ .fw-nav > [for="tab9-2"],
+#tab9-3:checked ~ .fw-nav > [for="tab9-3"] {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+  background: var(--bg-subtle);
+}
+
+.fw-content {
+  padding: var(--space-lg);
+}
+
+.fw-pane {
+  display: none;
+  font-size: var(--font-md);
+}
+
+#tab9-1:checked ~ .fw-content > :nth-child(1),
+#tab9-2:checked ~ .fw-content > :nth-child(2),
+#tab9-3:checked ~ .fw-content > :nth-child(3) {
+  display: block;
+}`} height={140} />
+    </section>
+
+    <section>
+      <h2 class="text-subheading font-semibold mb-vsp-sm">10. Minimal Tabs with Subtle Indicators</h2>
+      <HtmlPreview client:visible title="Minimal Tabs" html={`<div class="tabs-minimal">
+  <input type="radio" id="tab10-1" name="tabs10" checked>
+  <input type="radio" id="tab10-2" name="tabs10">
+  <input type="radio" id="tab10-3" name="tabs10">
+  <div class="minimal-nav">
+    <label for="tab10-1" class="minimal-tab">Feed</label>
+    <label for="tab10-2" class="minimal-tab">Trending</label>
+    <label for="tab10-3" class="minimal-tab">Saved</label>
+  </div>
+  <div class="minimal-content">
+    <div class="minimal-pane">Your personalized feed</div>
+    <div class="minimal-pane">What's trending now</div>
+    <div class="minimal-pane">Your saved items</div>
+  </div>
+</div>`} css={`.tabs-minimal input {
+  display: none;
+}
+
+.minimal-nav {
+  display: flex;
+  gap: var(--space-lg);
+  border-bottom: 1px solid var(--border);
+}
+
+.minimal-tab {
+  padding: var(--space-md) 0;
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: var(--font-md);
+  font-weight: 400;
+  position: relative;
+  transition: color 200ms;
+}
+
+.minimal-tab:hover {
+  color: var(--fg);
+}
+
+#tab10-1:checked ~ .minimal-nav > [for="tab10-1"],
+#tab10-2:checked ~ .minimal-nav > [for="tab10-2"],
+#tab10-3:checked ~ .minimal-nav > [for="tab10-3"] {
+  color: var(--fg);
+  font-weight: 500;
+}
+
+#tab10-1:checked ~ .minimal-nav > [for="tab10-1"]::after,
+#tab10-2:checked ~ .minimal-nav > [for="tab10-2"]::after,
+#tab10-3:checked ~ .minimal-nav > [for="tab10-3"]::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--fg-muted);
+  opacity: 0.3;
+}
+
+.minimal-content {
+  padding: var(--space-lg) 0;
+}
+
+.minimal-pane {
+  display: none;
+  font-size: var(--font-md);
+  color: var(--fg);
+}
+
+#tab10-1:checked ~ .minimal-content > :nth-child(1),
+#tab10-2:checked ~ .minimal-content > :nth-child(2),
+#tab10-3:checked ~ .minimal-content > :nth-child(3) {
+  display: block;
+}`} height={140} />
+    </section>
+  </div>
+</BaseLayout>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -91,3 +91,22 @@ body {
   font-weight: var(--font-weight-bold);
   margin: var(--spacing-vsp-xs) 0 var(--spacing-vsp-2xs);
 }
+
+/* ========================================
+ * Shiki highlighted code (.cssp-highlighted-code)
+ * ======================================== */
+
+.cssp-highlighted-code :where(pre) {
+  margin: 0;
+  padding: 0;
+  background: transparent !important;
+  font-size: var(--text-caption);
+  line-height: var(--leading-relaxed);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.cssp-highlighted-code :where(code) {
+  font-family: var(--font-mono);
+}


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-css-playground/issues/30
    - https://github.com/zudolab/zudo-css-playground/issues/27
    - https://github.com/zudolab/zudo-css-playground/issues/28
    - https://github.com/zudolab/zudo-css-playground/issues/29

---

## Summary
- Replace 3 color presets with Default Dark/Light from zudo-doc
- Add settings panel (gear icon) with CSS style + Shiki code theme selectors
- Add collapsible sidebar toggle with smooth animation
- Add Shiki syntax highlighting to demo code previews
- Fix demo iframe bg bleed-through and Tailwind mode

## Changes

### Color Schemes
- New Default Dark palette (warm amber accent, neutral grays)
- New Default Light palette (brown accent, cream backgrounds)
- Default Dark is the default; CSS token defaults updated to match
- Updated DemoTweakPanel colors to match new palette

### Settings Panel
- Gear icon in top-right icon area
- CSS Style selector: Tailwind CSS (real utility classes via CDN) vs General CSS (BEM-style)
- Code Theme selector: 14 Shiki themes with live preview
- Settings persisted in localStorage

### Collapsible Sidebar
- Toggle button at bottom-left with smooth margin-left transition
- localStorage persistence, is:inline for flash-free load
- ARIA attributes (aria-label, aria-expanded), CSS hover/focus

### Shiki Syntax Highlighting
- HighlightedCode component with lazy-loaded Shiki
- Replaces plain text code display in HtmlPreview
- Theme-aware: changes when Code Theme setting changes
- Fallback to plain text if Shiki fails to load

### Demo System Fixes
- iframe body now uses demo tokens for bg/fg (no app bg bleed-through)
- Tailwind CSS v4 browser CDN loaded in iframes
- New --demo-padding token with slider in Demo Tweak Panel > Etc tab

## Test Plan
- [x] TypeScript check passes
- [x] 56 unit tests pass
- [x] Production build passes
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)